### PR TITLE
Support AMD GPUs in auto VRAM-based model selection

### DIFF
--- a/SeedVR2DeviceUtils.cs
+++ b/SeedVR2DeviceUtils.cs
@@ -40,7 +40,7 @@ public static class SeedVR2DeviceUtils
     }
 
     /// <summary>
-    /// Lock protecting <see cref="_rocmCache"/>.
+    /// Lock protecting <see cref="_rocmCache"/> and <see cref="_amdVramCache"/>.
     /// A lock (rather than Lazy) is used so transient failures can be retried on the next call.
     /// </summary>
     private static readonly object _rocmProbeLock = new();
@@ -56,6 +56,16 @@ public static class SeedVR2DeviceUtils
     /// Zero means no backoff is active.
     /// </summary>
     private static long _rocmRetryAfter = 0;
+
+    /// <summary>
+    /// Cached AMD VRAM amount in GiB. Null means not yet probed or last probe was transient.
+    /// </summary>
+    private static double? _amdVramCache = null;
+
+    /// <summary>
+    /// Environment.TickCount64 value after which a transient AMD VRAM failure may be retried.
+    /// </summary>
+    private static long _amdVramRetryAfter = 0;
 
     /// <summary>
     /// Attempts to count AMD GPUs. Tries rocm-smi first (Linux); if rocm-smi is not installed,
@@ -278,6 +288,206 @@ public static class SeedVR2DeviceUtils
         catch
         {
             return (0, false);
+        }
+        finally
+        {
+            if (!definitive && p is not null)
+            {
+                KillProcess(p);
+                try { Task.WhenAll(stdoutTask ?? Task.CompletedTask, stderrTask ?? Task.CompletedTask).Wait(1000); } catch { }
+            }
+            p?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Attempts to detect AMD GPU VRAM in GiB using hipInfo.exe (Windows HIP SDK) or rocm-smi (Linux).
+    /// Returns null if AMD tools are unavailable or detection fails.
+    /// Result is cached after successful detection; transient failures apply a 60s backoff.
+    /// </summary>
+    public static double? DetectAmdVramGiB()
+    {
+        lock (_rocmProbeLock)
+        {
+            if (_amdVramCache.HasValue)
+            {
+                return _amdVramCache.Value;
+            }
+            if (_amdVramRetryAfter != 0 && Environment.TickCount64 < _amdVramRetryAfter)
+            {
+                return null; // backoff active
+            }
+
+            double? result = OperatingSystem.IsWindows()
+                ? ProbeHipInfoVramGiB()
+                : ProbeRocmSmiVramGiB();
+
+            if (result.HasValue)
+            {
+                _amdVramCache = result;
+            }
+            else
+            {
+                _amdVramRetryAfter = Environment.TickCount64 + 60_000; // retry in 60s
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Windows: queries hipInfo.exe for total GPU memory.
+    /// Parses lines of the form "memInfo.total: 19.98 GB" or "totalGlobalMem: 19.98 GB".
+    /// Returns the largest value found across all devices, or null on failure.
+    /// </summary>
+    private static double? ProbeHipInfoVramGiB()
+    {
+        const int BudgetMs = 5000;
+        Stopwatch sw = Stopwatch.StartNew();
+        Process p = null;
+        Task<string> stdoutTask = null;
+        Task stderrTask = null;
+        bool definitive = false;
+        try
+        {
+            string hipInfoExe = FindHipInfoPath();
+            ProcessStartInfo psi = new(hipInfoExe)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            try { p = Process.Start(psi); }
+            catch (Win32Exception ex) when (ex.NativeErrorCode == 2) { return null; } // hipInfo not installed — permanent
+            catch { return null; }                                                      // other launch error — transient
+            if (p is null)
+            {
+                return null;
+            }
+            // Drain stdout and stderr concurrently to prevent pipe buffer deadlocks.
+            stdoutTask = p.StandardOutput.ReadToEndAsync();
+            stderrTask = p.StandardError.ReadToEndAsync();
+            int ioRemaining = BudgetMs - (int)sw.ElapsedMilliseconds;
+            if (ioRemaining <= 0 || !Task.WhenAll(stdoutTask, stderrTask).Wait(ioRemaining))
+            {
+                return null; // transient timeout
+            }
+            int exitRemaining = BudgetMs - (int)sw.ElapsedMilliseconds;
+            if (exitRemaining <= 0 || !p.WaitForExit(exitRemaining))
+            {
+                return null; // transient timeout
+            }
+            if (p.ExitCode != 0)
+            {
+                return null;
+            }
+            double maxVram = 0;
+            foreach (string line in stdoutTask.Result.Split('\n'))
+            {
+                string trimmed = line.Trim();
+                if (!trimmed.StartsWith("memInfo.total:", StringComparison.OrdinalIgnoreCase) &&
+                    !trimmed.StartsWith("totalGlobalMem:", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                string[] parts = trimmed.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    if (parts[i].Equals("GB", StringComparison.OrdinalIgnoreCase) && i > 0)
+                    {
+                        string numberStr = parts[i - 1].TrimEnd(',', ':', ';');
+                        if (double.TryParse(numberStr, System.Globalization.NumberStyles.Any,
+                            System.Globalization.CultureInfo.InvariantCulture, out double gib) && gib > maxVram)
+                        {
+                            maxVram = gib;
+                        }
+                        break;
+                    }
+                }
+            }
+            definitive = true;
+            return maxVram > 0 ? maxVram : null;
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            if (!definitive && p is not null)
+            {
+                KillProcess(p);
+                try { Task.WhenAll(stdoutTask ?? Task.CompletedTask, stderrTask ?? Task.CompletedTask).Wait(1000); } catch { }
+            }
+            p?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Linux: queries rocm-smi for total VRAM across all AMD GPUs.
+    /// Returns the largest value found, or null if rocm-smi is unavailable or the probe fails.
+    /// </summary>
+    private static double? ProbeRocmSmiVramGiB()
+    {
+        const int BudgetMs = 5000;
+        Stopwatch sw = Stopwatch.StartNew();
+        Process p = null;
+        Task<string> stdoutTask = null;
+        Task stderrTask = null;
+        bool definitive = false;
+        try
+        {
+            ProcessStartInfo psi = new("rocm-smi", "--showmeminfo vram --csv")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            try { p = Process.Start(psi); }
+            catch (Win32Exception ex) when (ex.NativeErrorCode == 2) { return null; } // rocm-smi not installed — permanent
+            catch { return null; }
+            if (p is null)
+            {
+                return null;
+            }
+            stdoutTask = p.StandardOutput.ReadToEndAsync();
+            stderrTask = p.StandardError.ReadToEndAsync();
+            int ioRemaining = BudgetMs - (int)sw.ElapsedMilliseconds;
+            if (ioRemaining <= 0 || !Task.WhenAll(stdoutTask, stderrTask).Wait(ioRemaining))
+            {
+                return null;
+            }
+            int exitRemaining = BudgetMs - (int)sw.ElapsedMilliseconds;
+            if (exitRemaining <= 0 || !p.WaitForExit(exitRemaining))
+            {
+                return null;
+            }
+            if (p.ExitCode != 0)
+            {
+                return null;
+            }
+            double maxVram = 0;
+            bool firstLine = true;
+            foreach (string line in stdoutTask.Result.Split('\n'))
+            {
+                if (firstLine) { firstLine = false; continue; } // skip header
+                string[] parts = line.Split(',');
+                if (parts.Length >= 2 && long.TryParse(parts[1].Trim(), out long bytes))
+                {
+                    double gib = bytes / (1024.0 * 1024.0 * 1024.0);
+                    if (gib > maxVram)
+                    {
+                        maxVram = gib;
+                    }
+                }
+            }
+            definitive = true;
+            return maxVram > 0 ? maxVram : null;
+        }
+        catch
+        {
+            return null;
         }
         finally
         {

--- a/SeedVR2UpscalerExtension.cs
+++ b/SeedVR2UpscalerExtension.cs
@@ -564,69 +564,85 @@ public class SeedVR2UpscalerExtension : Extension
     }
 
     /// <summary>Detects available GPU VRAM and returns the best model configuration.</summary>
-    /// <returns>Tuple of (modelKey, blockSwap, tiledVAE) based on detected VRAM.</returns>
-    public static (string ModelKey, int BlockSwap, bool TiledVAE) DetectVRAMAndSelectModel()
-    {
-        try
-        {
-            NvidiaUtil.NvidiaInfo[] gpus = NvidiaUtil.QueryNvidia();
-            if (gpus is null || gpus.Length == 0)
-            {
-                Logs.Warning("SeedVR2 Auto: Could not detect GPU VRAM, defaulting to 3B FP8 with block swap");
-                return ("seedvr2-3b-fp8", 16, true);
-            }
+	/// <returns>Tuple of (modelKey, blockSwap, tiledVAE) based on detected VRAM.</returns>
+	public static (string ModelKey, int BlockSwap, bool TiledVAE) DetectVRAMAndSelectModel()
+	{
+		try
+		{
+			// Try NVIDIA first
+			NvidiaUtil.NvidiaInfo[] gpus = NvidiaUtil.QueryNvidia();
+			if (gpus is not null && gpus.Length > 0)
+			{
+				// Use the GPU with most VRAM
+				NvidiaUtil.NvidiaInfo bestGpu = gpus.OrderByDescending(g => g.TotalMemory.InBytes).First();
+				double vramGiB = bestGpu.TotalMemory.GiB;
 
-            // Use the GPU with most VRAM
-            NvidiaUtil.NvidiaInfo bestGpu = gpus.OrderByDescending(g => g.TotalMemory.InBytes).First();
-            double vramGiB = bestGpu.TotalMemory.GiB;
+				Logs.Info($"SeedVR2 Auto: Detected NVIDIA GPU '{bestGpu.GPUName}' with {vramGiB:F1} GiB VRAM");
+				return SelectModelByVram(vramGiB);
+			}
 
-            Logs.Info($"SeedVR2 Auto: Detected GPU '{bestGpu.GPUName}' with {vramGiB:F1} GiB VRAM");
+			// If no NVIDIA GPUs found, try AMD/ROCm
+			double? amdVram = SeedVR2DeviceUtils.DetectAmdVramGiB();
+			if (amdVram.HasValue)
+			{
+				double vramGiB = amdVram.Value;
+				Logs.Info($"SeedVR2 Auto: Detected AMD GPU with {vramGiB:F1} GiB VRAM");
+				return SelectModelByVram(vramGiB);
+			}
 
-            // Select model based on VRAM thresholds
-            // Note: These are conservative estimates accounting for base model already loaded
-            if (vramGiB >= 24)
-            {
-                // 24GB+: Can run 7B Sharp FP16 without block swap
-                Logs.Info("SeedVR2 Auto: Selected 7B Sharp FP16 (max quality)");
-                return ("seedvr2-7b-sharp-fp16", 0, false);
-            }
-            else if (vramGiB >= 20)
-            {
-                // 20-24GB: 7B FP8 with light block swap
-                Logs.Info("SeedVR2 Auto: Selected 7B FP8 with block swap 8");
-                return ("seedvr2-7b-fp8", 8, false);
-            }
-            else if (vramGiB >= 16)
-            {
-                // 16-20GB: 7B Q4 or 3B FP16 with block swap
-                Logs.Info("SeedVR2 Auto: Selected 7B Q4 with block swap 16");
-                return ("seedvr2-7b-q4", 16, true);
-            }
-            else if (vramGiB >= 12)
-            {
-                // 12-16GB: 3B FP8 with moderate block swap
-                Logs.Info("SeedVR2 Auto: Selected 3B FP8 with block swap 12");
-                return ("seedvr2-3b-fp8", 12, true);
-            }
-            else if (vramGiB >= 8)
-            {
-                // 8-12GB: 3B Q4 with heavy block swap
-                Logs.Info("SeedVR2 Auto: Selected 3B Q4 with block swap 20");
-                return ("seedvr2-3b-q4", 20, true);
-            }
-            else
-            {
-                // <8GB: 3B Q4 with maximum block swap, tiled VAE
-                Logs.Warning($"SeedVR2 Auto: Low VRAM ({vramGiB:F1} GiB) - using 3B Q4 with maximum optimization");
-                return ("seedvr2-3b-q4", 28, true);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logs.Warning($"SeedVR2 Auto: Error detecting VRAM: {ex.Message}, defaulting to 3B FP8");
-            return ("seedvr2-3b-fp8", 16, true);
-        }
-    }
+			// If both failed, fall back to default
+			Logs.Warning("SeedVR2 Auto: Could not detect GPU VRAM (no NVIDIA or AMD GPUs found), defaulting to 3B FP8");
+			return ("seedvr2-3b-fp8", 16, true);
+		}
+		catch (Exception ex)
+		{
+			Logs.Warning($"SeedVR2 Auto: Error detecting VRAM: {ex.Message}, defaulting to 3B FP8");
+			return ("seedvr2-3b-fp8", 16, true);
+		}
+	}
+
+	/// <summary>Selects model configuration based on VRAM amount. Shared logic for NVIDIA and AMD.</summary>
+	private static (string ModelKey, int BlockSwap, bool TiledVAE) SelectModelByVram(double vramGiB)
+	{
+		// Select model based on VRAM thresholds
+		// Note: These are conservative estimates accounting for base model already loaded
+		if (vramGiB >= 24)
+		{
+			// 24GB+: Can run 7B Sharp FP16 without block swap
+			Logs.Info("SeedVR2 Auto: Selected 7B Sharp FP16 (max quality)");
+			return ("seedvr2-7b-sharp-fp16", 0, false);
+		}
+		else if (vramGiB >= 20)
+		{
+			// 20-24GB: 7B FP8 with light block swap
+			Logs.Info("SeedVR2 Auto: Selected 7B FP8 with block swap 8");
+			return ("seedvr2-7b-fp8", 8, false);
+		}
+		else if (vramGiB >= 16)
+		{
+			// 16-20GB: 7B Q4 or 3B FP16 with block swap
+			Logs.Info("SeedVR2 Auto: Selected 7B Q4 with block swap 16");
+			return ("seedvr2-7b-q4", 16, true);
+		}
+		else if (vramGiB >= 12)
+		{
+			// 12-16GB: 3B FP8 with moderate block swap
+			Logs.Info("SeedVR2 Auto: Selected 3B FP8 with block swap 12");
+			return ("seedvr2-3b-fp8", 12, true);
+		}
+		else if (vramGiB >= 8)
+		{
+			// 8-12GB: 3B Q4 with heavy block swap
+			Logs.Info("SeedVR2 Auto: Selected 3B Q4 with block swap 20");
+			return ("seedvr2-3b-q4", 20, true);
+		}
+		else
+		{
+			// <8GB: 3B Q4 with maximum block swap, tiled VAE
+			Logs.Warning($"SeedVR2 Auto: Low VRAM ({vramGiB:F1} GiB) - using 3B Q4 with maximum optimization");
+			return ("seedvr2-3b-q4", 28, true);
+		}
+	}
 
     /// <summary>Returns true if the current generation request is producing video output.</summary>
     private static bool IsSeedVR2VideoGenerationRequest(WorkflowGenerator g)


### PR DESCRIPTION
Adds VRAM detection for AMD GPUs so the "Auto" model preset works for ROCm/HIP users.

- Detects AMD VRAM via `hipInfo.exe` on Windows and `rocm-smi` on Linux.
- Falls back to AMD detection if no NVIDIA GPUs are found.
- Caches detection results to avoid subprocess spawning on every generation.

**Note:** Tested on Windows. Linux support is implemented based on `rocm-smi` documentation but has not been tested.