### PR TITLE
Fix presets not applying Tiled VAE setting correctly

### DIFF
--- a/SeedVR2UpscalerExtension.cs
+++ b/SeedVR2UpscalerExtension.cs
@@ -371,6 +371,7 @@ public class SeedVR2UpscalerExtension : Extension
             "Enable tiled VAE encoding/decoding for large images.\nReduces VRAM usage but may be slightly slower.\nNote: Presets auto-configure this value.",
             "false",
             IsAdvanced: true,
+			Toggleable: true,
             FeatureFlag: "seedvr2_upscaler",
             Group: SeedVR2Group,
             OrderPriority: 6

--- a/SeedVR2UpscalerExtension.cs
+++ b/SeedVR2UpscalerExtension.cs
@@ -371,7 +371,7 @@ public class SeedVR2UpscalerExtension : Extension
             "Enable tiled VAE encoding/decoding for large images.\nReduces VRAM usage but may be slightly slower.\nNote: Presets auto-configure this value.",
             "false",
             IsAdvanced: true,
-			Toggleable: true,
+            Toggleable: true,
             FeatureFlag: "seedvr2_upscaler",
             Group: SeedVR2Group,
             OrderPriority: 6


### PR DESCRIPTION
Fixes a bug where quality presets (Fast, Quality, etc.) ignored their intended Tiled VAE configuration.

The `SeedVR2TiledVAE` parameter was missing `Toggleable: true`, causing the default UI value (`false`) to override the preset's value. This ensures presets work as intended unless explicitly overridden by the user.