### PR TITLE
Fix: Skip video model params when preserving source metadata during upscaling

### DIFF
--- a/SeedVR2UpscalerExtension.cs
+++ b/SeedVR2UpscalerExtension.cs
@@ -1977,7 +1977,7 @@ public class SeedVR2UpscalerExtension : Extension
     private static readonly HashSet<string> SkipSourceMetadataParams =
     [
         // Model params - may reference models that no longer exist (fixes issue #13)
-        "model", "refinermodel", "loras", "loraweights", "loratencweights",
+        "model", "refinermodel", "videomodel", "videoswapmodel", "loras", "loraweights", "loratencweights",
         // Resolution params - determined by source image, not original generation
         "width", "height", "aspectratio", "sidelength", "altresolutionheightmult", "rawresolution",
         // Backend params - not relevant for file upscaling

--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -100,7 +100,7 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
                                             if (metadataParsed.sui_image_params) {
                                                 // Params to skip - not used in file upscaling or could cause validation errors
                                                 let skipParams = [
-                                                    'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights',  // Models may not exist
+                                                    'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights', 'loratencweights'  // Models may not exist
                                                     'images', 'swarm_version',  // Special params
                                                     'width', 'height', 'aspectratio', 'sidelength'  // Resolution comes from source image
                                                 ];

--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -100,7 +100,7 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
                                             if (metadataParsed.sui_image_params) {
                                                 // Params to skip - not used in file upscaling or could cause validation errors
                                                 let skipParams = [
-                                                    'model', 'refinermodel', 'loras', 'loraweights',  // Models may not exist
+                                                    'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights',  // Models may not exist
                                                     'images', 'swarm_version',  // Special params
                                                     'width', 'height', 'aspectratio', 'sidelength'  // Resolution comes from source image
                                                 ];


### PR DESCRIPTION
Fixes this error I got when using the SeedVR2 Upscale button on existing videos.

`Invalid value for parameter Video Model: Invalid model value for param Video Model - 'DasiwaWAN22I2V14BSynthseduction_q5High.gguf'`

The extension was copying the video model name from the source image's metadata, but that model might not exist on the current system. Now `videomodel` and `videoswapmodel` get skipped alongside the other model params (model, refiner, loras, etc.).

Changes in both `SeedVR2UpscalerExtension.cs` and `seedvr2_install.js`.