### PR TITLE
Fix preset Tiled VAE and Block Swap values being overridden by UI defaults

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Rasmus Lerdorf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -79,6 +79,11 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
                                 for (let paramId of seedvr2Params) {
                                     let elem = document.getElementById('input_' + paramId);
                                     if (elem) {
+                                        // Skip toggleable params whose toggle is off (same logic as simpletab.js)
+                                        let toggleElem = document.getElementById('input_' + paramId + '_toggle');
+                                        if (toggleElem && !toggleElem.checked) {
+                                            continue;
+                                        }
                                         let val = typeof getInputVal === 'function' ? getInputVal(elem, true) : elem.value;
                                         if (val != null && val !== '') {
                                             input_overrides[paramId] = val;


### PR DESCRIPTION
Fixes #28.

Two separate code paths both caused preset-configured values to be silently overridden by the UI's default state.

`SeedVR2 Tiled VAE` is now a toggleable parameter. Users who had it manually set to `true` and persisted across sessions will need to re-enable the toggle once after upgrading. The default behavior (toggle off) means presets now correctly control this value.