### PR TITLE
Fixes #30

### DIFF
--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -5,136 +5,109 @@
 addInstallButton('seedvrupscaler', 'seedvr2_upscaler', 'seedvr2_upscaler', 'Install SeedVR2 Upscaler Node');
 addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upscaler', 'Install SeedVR2 Image Upscaler Node');
 
-// Add SeedVR2 Upscale button to image/video context menus
+// Add SeedVR2 Upscale button to image/video context menus via SwarmUI's registerMediaButton API
 (function() {
-    // Video file extensions supported by SeedVR2
     let videoExtensions = ['mp4', 'webm', 'gif', 'mov', 'avi', 'mkv'];
 
-    // Wait for buttonsForImage to be defined, then wrap it
-    let checkInterval = setInterval(() => {
-        if (typeof buttonsForImage === 'function') {
-            clearInterval(checkInterval);
+    registerMediaButton(
+        'SeedVR2 Upscale',
+        (src) => {
+            if (typeof currentBackendFeatureSet === 'undefined' || !currentBackendFeatureSet.includes('seedvr2_upscaler')) {
+                return;
+            }
 
-            // Store original function
-            let originalButtonsForImage = buttonsForImage;
+            let isDataImage = src.startsWith('data:');
+            let isVideo = false;
+            if (!isDataImage) {
+                let extension = src.split('.').pop().toLowerCase().split('?')[0];
+                isVideo = videoExtensions.includes(extension);
+            }
 
-            // Replace with wrapped version
-            buttonsForImage = function(fullsrc, src, metadata) {
-                // Call original function
-                let buttons = originalButtonsForImage(fullsrc, src, metadata);
+            // Data URL videos are not supported
+            if (isVideo && isDataImage) {
+                return;
+            }
 
-                // Only add SeedVR2 button if feature is available
-                if (typeof currentBackendFeatureSet !== 'undefined' &&
-                    currentBackendFeatureSet.includes('seedvr2_upscaler')) {
+            let input_overrides = { 'images': 1 };
 
-                    // Check if this is a data URL (drag & dropped image)
-                    let isDataImage = src.startsWith('data:');
+            if (isDataImage) {
+                input_overrides['seedvr2imagefile'] = src;
+            } else {
+                let fullsrc = typeof getImageFullSrc === 'function' ? getImageFullSrc(src) : src;
+                let prefix = typeof getImageOutPrefix === 'function' ? getImageOutPrefix() : 'Output';
+                let filePath = prefix + '/' + fullsrc;
+                if (isVideo) {
+                    input_overrides['seedvr2videofile'] = filePath;
+                } else {
+                    input_overrides['seedvr2imagefile'] = filePath;
+                }
+            }
 
-                    // Determine if this is a video or image based on extension (for file paths)
-                    // Data URLs are always images (video data URLs aren't supported)
-                    let isVideo = false;
-                    if (!isDataImage) {
-                        let extension = src.split('.').pop().toLowerCase().split('?')[0];
-                        isVideo = videoExtensions.includes(extension);
+            // Read SeedVR2 params from UI (fixes issue #14)
+            // Note: SwarmUI strips "2" from "SeedVR2" when creating element IDs
+            let seedvr2Params = [
+                'seedvrmodel', 'seedvrupscaleby', 'seedvrresolution', 'seedvrblockswap',
+                'seedvrcolorcorrection', 'seedvrtwostepmode', 'seedvrpredownscale', 'seedvrtiledvae',
+                'seedvrlatentnoisescale', 'seedvrinputnoisescale', 'seedvrcachemodel', 'seedvrattentionmode',
+                'seedvrvaeoffloaddevice', 'seedvrvideobatchsize', 'seedvrtemporaloverlap', 'seedvruniformbatchsize',
+                'seedvrimagetilesize', 'seedvrimagemaskblur', 'seedvrimagetileoverlap',
+                'seedvrimagetileupscaleresolution', 'seedvrimagetilingstrategy', 'seedvrimageantialiasingstrength',
+                'seedvrimageblendingmethod',
+            ];
+
+            for (let paramId of seedvr2Params) {
+                let elem = document.getElementById('input_' + paramId);
+                if (elem) {
+                    // Skip toggleable params whose toggle is off (same logic as simpletab.js)
+                    let toggleElem = document.getElementById('input_' + paramId + '_toggle');
+                    if (toggleElem && !toggleElem.checked) {
+                        continue;
                     }
-
-                    // Skip data URL videos (not supported), but allow data URL images
-                    if (!isVideo || !isDataImage) {
-                        buttons.push({
-                            label: 'SeedVR2 Upscale',
-                            title: 'Upscale this ' + (isVideo ? 'video' : 'image') + ' using SeedVR2 AI upscaler',
-                            onclick: (e) => {
-                                // Build input overrides with the appropriate file parameter
-                                let input_overrides = {
-                                    'images': 1
-                                };
-
-                                if (isDataImage) {
-                                    // For data URLs (drag & dropped images), pass the data URL directly
-                                    input_overrides['seedvr2imagefile'] = src;
-                                } else {
-                                    // For file paths, use getImageOutPrefix() for correct prefix
-                                    let prefix = typeof getImageOutPrefix === 'function' ? getImageOutPrefix() : 'Output';
-                                    let filePath = prefix + '/' + fullsrc;
-
-                                    if (isVideo) {
-                                        input_overrides['seedvr2videofile'] = filePath;
-                                    } else {
-                                        input_overrides['seedvr2imagefile'] = filePath;
-                                    }
-                                }
-
-                                // Read SeedVR2 params from UI (fixes issue #14)
-                                // Note: SwarmUI strips "2" from "SeedVR2" when creating element IDs
-                                let seedvr2Params = [
-                                    'seedvrmodel', 'seedvrupscaleby', 'seedvrresolution', 'seedvrblockswap',
-                                    'seedvrcolorcorrection', 'seedvrtwostepmode', 'seedvrpredownscale', 'seedvrtiledvae',
-                                    'seedvrlatentnoisescale', 'seedvrinputnoisescale', 'seedvrcachemodel', 'seedvrattentionmode',
-                                    'seedvrvaeoffloaddevice', 'seedvrvideobatchsize', 'seedvrtemporaloverlap', 'seedvruniformbatchsize',
-                                    'seedvrimagetilesize', 'seedvrimagemaskblur', 'seedvrimagetileoverlap',
-                                    'seedvrimagetileupscaleresolution', 'seedvrimagetilingstrategy', 'seedvrimageantialiasingstrength',
-                                    'seedvrimageblendingmethod',
-                                ];
-
-                                for (let paramId of seedvr2Params) {
-                                    let elem = document.getElementById('input_' + paramId);
-                                    if (elem) {
-                                        // Skip toggleable params whose toggle is off (same logic as simpletab.js)
-                                        let toggleElem = document.getElementById('input_' + paramId + '_toggle');
-                                        if (toggleElem && !toggleElem.checked) {
-                                            continue;
-                                        }
-                                        let val = typeof getInputVal === 'function' ? getInputVal(elem, true) : elem.value;
-                                        if (val != null && val !== '') {
-                                            input_overrides[paramId] = val;
-                                        }
-                                    }
-                                }
-
-                                // Ensure seedvrmodel is always set - use default if nothing else found
-                                if (!input_overrides['seedvrmodel']) {
-                                    input_overrides['seedvrmodel'] = 'seedvr2-auto';
-                                }
-
-                                // Preserve original image metadata (fixes issue #12)
-                                if (metadata) {
-                                    try {
-                                        let readable = typeof interpretMetadata === 'function' ? interpretMetadata(metadata) : metadata;
-                                        if (readable) {
-                                            let metadataParsed = JSON.parse(readable);
-                                            if (metadataParsed.sui_image_params) {
-                                                // Params to skip - not used in file upscaling or could cause validation errors
-                                                let skipParams = [
-                                                    'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights', 'loratencweights'  // Models may not exist
-                                                    'images', 'swarm_version',  // Special params
-                                                    'width', 'height', 'aspectratio', 'sidelength'  // Resolution comes from source image
-                                                ];
-                                                for (let key in metadataParsed.sui_image_params) {
-                                                    let keyLower = key.toLowerCase();
-                                                    // Skip SeedVR2 params (use current UI settings) and params in skip list
-                                                    if (!keyLower.startsWith('seedvr') &&
-                                                        !skipParams.includes(keyLower)) {
-                                                        input_overrides[key] = metadataParsed.sui_image_params[key];
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    } catch (e) {
-                                        console.log('SeedVR2: Could not parse original metadata:', e);
-                                    }
-                                }
-
-                                // Trigger generation with the file parameter
-                                if (typeof mainGenHandler !== 'undefined' && mainGenHandler.doGenerate) {
-                                    mainGenHandler.doGenerate(input_overrides, {});
-                                }
-                            }
-                        });
+                    let val = typeof getInputVal === 'function' ? getInputVal(elem, true) : elem.value;
+                    if (val != null && val !== '') {
+                        input_overrides[paramId] = val;
                     }
                 }
+            }
 
-                return buttons;
-            };
-        }
-    }, 100);
+            if (!input_overrides['seedvrmodel']) {
+                input_overrides['seedvrmodel'] = 'seedvr2-auto';
+            }
+
+            // Preserve original image metadata (fixes issue #12)
+            // currentMetadataVal is a SwarmUI global holding the currently displayed image's metadata
+            let metadata = typeof currentMetadataVal !== 'undefined' ? currentMetadataVal : null;
+            if (metadata) {
+                try {
+                    let readable = typeof interpretMetadata === 'function' ? interpretMetadata(metadata) : metadata;
+                    if (readable) {
+                        let metadataParsed = JSON.parse(readable);
+                        if (metadataParsed.sui_image_params) {
+                            let skipParams = [
+                                'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights', 'loratencweights',  // Models may not exist
+                                'images', 'swarm_version',  // Special params
+                                'width', 'height', 'aspectratio', 'sidelength'  // Resolution comes from source image
+                            ];
+                            for (let key in metadataParsed.sui_image_params) {
+                                let keyLower = key.toLowerCase();
+                                if (!keyLower.startsWith('seedvr') && !skipParams.includes(keyLower)) {
+                                    input_overrides[key] = metadataParsed.sui_image_params[key];
+                                }
+                            }
+                        }
+                    }
+                } catch (e) {
+                    console.log('SeedVR2: Could not parse original metadata:', e);
+                }
+            }
+
+            if (typeof mainGenHandler !== 'undefined' && mainGenHandler.doGenerate) {
+                mainGenHandler.doGenerate(input_overrides, {});
+            }
+        },
+        'Upscale this image/video using SeedVR2 AI upscaler',
+        null,   // mediaTypes: null = images + videos
+        false,  // isDefault: stays in "More" dropdown
+        true    // showInHistory
+    );
 })();

--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -18,6 +18,11 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
         'SeedVR2 Upscale',
         (src) => {
             if (typeof currentBackendFeatureSet === 'undefined' || !currentBackendFeatureSet.includes('seedvr2_upscaler')) {
+                let message = 'SeedVR2 Upscaler is not available on the current backend. Please install or enable the SeedVR2 Upscaler node first.';
+                console.warn('SeedVR2: ' + message);
+                if (typeof showToast === 'function') {
+                    showToast(message);
+                }
                 return;
             }
 
@@ -89,14 +94,17 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
                     if (readable) {
                         let metadataParsed = JSON.parse(readable);
                         if (metadataParsed.sui_image_params) {
-                            let skipParams = [
+                            // Normalize param keys the same way as C#'s T2IParamTypes.CleanTypeName: lowercase letters only
+                            let normalizeKey = (key) => String(key).toLowerCase().replace(/[^a-z]/g, '');
+                            let skipParams = new Set([
                                 'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights', 'loratencweights',  // Models may not exist
-                                'images', 'swarm_version',  // Special params
-                                'width', 'height', 'aspectratio', 'sidelength'  // Resolution comes from source image
-                            ];
+                                'images', 'swarmversion',  // Special params
+                                'width', 'height', 'aspectratio', 'sidelength', 'altresolutionheightmult', 'rawresolution',  // Resolution comes from source image
+                                'internalbackendtype', 'exactbackendid'  // Backend params not relevant for file upscaling
+                            ]);
                             for (let key in metadataParsed.sui_image_params) {
-                                let keyLower = key.toLowerCase();
-                                if (!keyLower.startsWith('seedvr') && !skipParams.includes(keyLower)) {
+                                let normalizedKey = normalizeKey(key);
+                                if (!normalizedKey.startsWith('seedvr') && !skipParams.has(normalizedKey)) {
                                     input_overrides[key] = metadataParsed.sui_image_params[key];
                                 }
                             }

--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -7,6 +7,11 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
 
 // Add SeedVR2 Upscale button to image/video context menus via SwarmUI's registerMediaButton API
 (function() {
+    if (typeof registerMediaButton !== 'function') {
+        console.warn('SeedVR2: registerMediaButton is not available - SwarmUI version may be too old');
+        return;
+    }
+
     let videoExtensions = ['mp4', 'webm', 'gif', 'mov', 'avi', 'mkv'];
 
     registerMediaButton(
@@ -17,14 +22,15 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
             }
 
             let isDataImage = src.startsWith('data:');
-            let isVideo = false;
+            let isDataVideo = isDataImage && src.toLowerCase().startsWith('data:video/');
+            let isVideo = isDataVideo;
             if (!isDataImage) {
                 let extension = src.split('.').pop().toLowerCase().split('?')[0];
                 isVideo = videoExtensions.includes(extension);
             }
 
             // Data URL videos are not supported
-            if (isVideo && isDataImage) {
+            if (isDataVideo) {
                 return;
             }
 

--- a/assets/seedvr2_install.js
+++ b/assets/seedvr2_install.js
@@ -96,9 +96,14 @@ addInstallButton('seedvrupscaler', 'seedvr2_image_upscaler', 'seedvr2_image_upsc
                         if (metadataParsed.sui_image_params) {
                             // Normalize param keys the same way as C#'s T2IParamTypes.CleanTypeName: lowercase letters only
                             let normalizeKey = (key) => String(key).toLowerCase().replace(/[^a-z]/g, '');
+                            // Mirrors C#'s SkipSourceMetadataParams, plus JS-only entries:
+                            // - 'images': C# ignores it implicitly via workflow logic; JS must skip explicitly
+                            //   to prevent a batch-count from metadata overriding input_overrides['images']=1
+                            // - 'swarmversion': C# filters it via TryGetType (not a registered param);
+                            //   JS has no type-check fallback so must skip it explicitly
                             let skipParams = new Set([
                                 'model', 'refinermodel', 'videomodel', 'videoswapmodel', 'loras', 'loraweights', 'loratencweights',  // Models may not exist
-                                'images', 'swarmversion',  // Special params
+                                'images', 'swarmversion',  // JS-only: see comment above
                                 'width', 'height', 'aspectratio', 'sidelength', 'altresolutionheightmult', 'rawresolution',  // Resolution comes from source image
                                 'internalbackendtype', 'exactbackendid'  // Backend params not relevant for file upscaling
                             ]);


### PR DESCRIPTION
## Migrate context menu button to registerMediaButton API

Fixes #30.

## Problem

The "SeedVR2 Upscale" button disappeared from the More menu after a SwarmUI update. Two root causes:

1. **Syntax error**: A missing comma after `'loratencweights'` in the `skipParams` array caused a JavaScript parse failure, crashing the entire script silently.

2. **Fragile monkey-patch**: The button was injected by polling with `setInterval` until `buttonsForImage` was defined, then wrapping it. SwarmUI has since added `registerMediaButton` as the proper extension API for this purpose, and reorganized the internals in a way that broke the old approach.

## Changes

Replaces the `setInterval`/monkey-patch approach with a single `registerMediaButton` call, which is how SwarmUI intends extensions to add context menu buttons.

`fullsrc` and `metadata`: previously received as parameters via the wrapped function are recovered from SwarmUI globals:
- `getImageFullSrc(src)`: strips URL and `Output/` prefixes, same transformation SwarmUI applies internally
- `currentMetadataVal`: SwarmUI global that always holds the currently displayed image's metadata

Also fixes the pre-existing asymmetry between the C# and JS skip lists: `loratencweights` was in `SkipSourceMetadataParams` (C#) but missing from `skipParams` (JS). The JS list now mirrors the C# list, plus two JS-only entries (`images`, `swarmversion`) that C# handles implicitly via workflow logic and `TryGetType` filtering respectively, but JS must skip explicitly since it has no equivalent fallback.