### PR TITLE
Vendor a fixed copy of the SeedVR2 Image Upscaler node

### DIFF
--- a/SeedVR2UpscalerExtension.cs
+++ b/SeedVR2UpscalerExtension.cs
@@ -254,6 +254,18 @@ public class SeedVR2UpscalerExtension : Extension
             ComfyUISelfStartBackend.FoldersToForwardInComfyPath.Add("seedvr2");
         }
 
+        // Register our own vendored copy of the SeedVR2 Image Upscaler node (python/README.md
+        // has the full rationale). ComfyUI loads custom_nodes roots in the order SwarmUI lists
+        // them (DLNodes, then ExtraNodes, then CustomNodePaths) and last-registered wins for a
+        // given node name with no duplicate-name warning, so this deterministically overrides
+        // SwarmUI core's bundled (buggy, tile-color-drift) copy under DLNodes without needing
+        // any change to SwarmUI core or a merged upstream PR.
+        string vendoredPythonNodesPath = Path.GetFullPath($"{FilePath}python");
+        if (Directory.Exists(vendoredPythonNodesPath) && !ComfyUISelfStartBackend.CustomNodePaths.Contains(vendoredPythonNodesPath))
+        {
+            ComfyUISelfStartBackend.CustomNodePaths.Add(vendoredPythonNodesPath);
+        }
+
         ScanForDiscoveredModels();
 
         // Register installable feature for the SeedVR2 ComfyUI node

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/LICENSE
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juan Treminio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/__init__.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/__init__.py
@@ -1,0 +1,29 @@
+"""SeedVR2 Image Upscaler - ComfyUI custom node for memory-efficient image upscaling."""
+
+import os
+from PIL import Image
+from .seedvr2_image_upscaler import comfy_entrypoint, SeedVR2ImageUpscaler
+
+# Large stitched outputs can exceed Pillow's decompression-bomb threshold
+# for legitimate upscaling jobs.
+#
+# Default behavior here is unlimited pixels.
+# To enforce a limit, explicitly set:
+#   SEEDVR2_MAX_IMAGE_PIXELS=<int>   (for example: 500000000)
+# To force-disable checks via env value:
+#   SEEDVR2_MAX_IMAGE_PIXELS=none
+def _set_max_pixels():
+    _max_pixels_env = os.getenv("SEEDVR2_MAX_IMAGE_PIXELS", "").strip()
+    Image.MAX_IMAGE_PIXELS = None
+    if not _max_pixels_env or _max_pixels_env.lower() in {"none", "disable", "unlimited", "0"}:
+        return
+
+    try:
+        parsed_limit = int(_max_pixels_env)
+        Image.MAX_IMAGE_PIXELS = parsed_limit if parsed_limit > 0 else None
+    except ValueError:
+        return
+
+_set_max_pixels()
+
+__all__ = ["comfy_entrypoint", "SeedVR2ImageUpscaler"]

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/requirements.txt
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/requirements.txt
@@ -1,0 +1,5 @@
+torch>=1.9.0
+numpy>=1.21.0
+Pillow>=8.0.0
+scipy>=1.7.0
+opencv-python>=4.5.0

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/__init__.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/__init__.py
@@ -1,0 +1,20 @@
+from comfy_api.latest import ComfyExtension, io
+
+from .image_upscaler import SeedVR2ImageUpscaler
+
+
+class SeedVR2ImageUpscalerExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            SeedVR2ImageUpscaler,
+        ]
+
+
+async def comfy_entrypoint() -> ComfyExtension:
+    return SeedVR2ImageUpscalerExtension()
+
+
+__all__ = [
+    "SeedVR2ImageUpscaler",
+    "comfy_entrypoint",
+]

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/image_upscaler.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/image_upscaler.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+import torch
+from comfy_api.latest import io
+
+from .progress import Progress
+from .image_utils import ImageUtils
+from .logger import Logger
+from .tiling import TileUtils
+from .stitching import StitchingPipeline
+
+class SeedVR2ImageUpscaler(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="SeedVR2ImageUpscaler",
+            display_name="SeedVR2 Image Upscaler",
+            category="SEEDVR2",
+            description="Tiled upscaling node that wraps SeedVR2 for memory-efficient processing",
+            inputs=[
+                io.Image.Input("image",
+                    tooltip=("Input image to upscale.")
+                ),
+                io.Custom("SEEDVR2_DIT").Input("dit",
+                    tooltip="DiT model configuration from 'SeedVR2 (Down)Load DiT Model' node"
+                ),
+                io.Custom("SEEDVR2_VAE").Input("vae",
+                    tooltip="VAE model configuration from 'SeedVR2 (Down)Load VAE Model' node"
+                ),
+                io.Int.Input("seed",
+                    default=42,
+                    min=0,
+                    max=2**32 - 1,
+                    step=1,
+                    tooltip=(
+                        "Random seed for reproducible generation (default: 42).\n"
+                        "Same seed with same inputs produces identical output."
+                    )
+                ),
+                io.Int.Input("resolution",
+                    default=1080,
+                    min=16,
+                    step=2,
+                    tooltip=(
+                        "Target resolution for the shortest edge in pixels (default: 1080).\n"
+                        "Automatically maintains aspect ratio of input.\n"
+                        "Even values required for optimal processing."
+                    )
+                ),
+                io.Int.Input("tile_size",
+                    default=512,
+                    min=64,
+                    max=8192,
+                    step=8,
+                    tooltip=(
+                        "Square tile size in pixels (applied to both width and height).\n"
+                        "Smaller tiles use less VRAM but may show more seams."
+                    )
+                ),
+                io.Int.Input("mask_blur",
+                    default=0,
+                    min=0,
+                    max=64,
+                    step=1,
+                    tooltip=(
+                        "Tile edge blending.\n"
+                        "0=multi-band frequency separation (best detail)\n"
+                        "1-3=minimal blur\n"
+                        "4+=traditional blur."
+                    )
+                ),
+                io.Int.Input("tile_overlap",
+                    default=32,
+                    min=0,
+                    max=8192,
+                    step=8,
+                    tooltip=(
+                        "Overlap between tiles in pixels.\n"
+                        "Higher values reduce seams but increase processing time.\n"
+                        "Recommended: 32-64."
+                    )
+                ),
+                io.Int.Input("tile_upscale_resolution",
+                    default=0,
+                    min=0,
+                    max=8192,
+                    step=8,
+                    optional=True,
+                    tooltip=(
+                        "Resolution for upscaling each tile.\n"
+                        "Set 0 to auto-infer from tile_size and output scale.\n"
+                        "Higher=better quality but more VRAM."
+                    )
+                ),
+                io.Combo.Input("tiling_strategy",
+                    options=["Linear", "Chess"],
+                    default="Linear",
+                    tooltip=(
+                        "Tile processing order.\n"
+                        "Chess=checkerboard pattern for better blending,\n"
+                        "Linear=row-by-row (faster)."
+                    )
+                ),
+                io.Float.Input("anti_aliasing_strength",
+                    default=0.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.05,
+                    optional=True,
+                    tooltip=(
+                        "Edge-aware smoothing strength (default: 0.0, disabled).\n"
+                        "Adds subtle smoothing to image edges.\n"
+                        "Range: 0.0 (no smoothing) to 1.0 (maximum smoothing).\n"
+                        "Can help with certain types of artifacts."
+                    )
+                ),
+                io.Combo.Input("blending_method",
+                    options=["auto", "multiband", "bilateral", "content_aware", "linear", "simple"],
+                    default="auto",
+                    tooltip=(
+                        "Blending algorithm.\n"
+                        "auto (mask_blur based)\n"
+                        "multiband (Laplacian pyramid/frequency separation)\n"
+                        "bilateral (edge-preserving filter)\n"
+                        "content_aware (structure-adaptive)\n"
+                        "linear (alpha blend)\n"
+                        "simple (pixel averaging)."
+                    )
+                ),
+                io.Combo.Input("color_correction",
+                    options=["lab", "wavelet", "wavelet_adaptive", "hsv", "adain", "none"],
+                    default="lab",
+                    tooltip=(
+                        "Corrects color shifts in upscaled output to match original input (default: lab).\n"
+                        "The upscaling process may alter colors; this applies color grading to restore them.\n"
+                        "\n"
+                        "• lab: Perceptual color matching with detail preservation (recommended)\n"
+                        "• wavelet: Frequency-based natural colors, preserves fine details\n"
+                        "• wavelet_adaptive: Wavelet base with targeted saturation correction\n"
+                        "• hsv: Hue-conditional saturation matching\n"
+                        "• adain: Statistical style transfer approach\n"
+                        "• none: No color correction applied"
+                    )
+                ),
+                io.Float.Input("input_noise_scale",
+                    default=0.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.001,
+                    optional=True,
+                    tooltip=(
+                        "Input noise injection scale (default: 0.0, disabled).\n"
+                        "Adds controlled variation to input images before encoding.\n"
+                        "Range: 0.0 (no noise) to 1.0 (maximum noise).\n"
+                        "Can help with certain types of artifacts."
+                    )
+                ),
+                io.Combo.Input("offload_device",
+                    options=SeedVR2ImageUpscaler._get_device_list(include_none=True, include_cpu=True),
+                    default="cpu",
+                    optional=True,
+                    tooltip=(
+                        "Device for storing intermediate tensors between processing phases (default: cpu).\n"
+                        "• 'none': Keep all tensors on inference device (fastest but highest VRAM usage)\n"
+                        "• 'cpu': Offload to system RAM (recommended for long videos, slower transfers)\n"
+                        "• 'cuda:X': Offload to another GPU (good balance if available, faster than CPU)"
+                    )
+                ),
+                io.Boolean.Input("enable_debug",
+                    default=False,
+                    optional=True,
+                    tooltip=(
+                        "Enable detailed debug logging (default: False).\n"
+                        "Shows memory usage, timing information, and processing details.\n"
+                        "Useful for troubleshooting errors and performance issues."
+                    )
+                ),
+            ],
+            outputs=[
+                io.Image.Output(
+                    tooltip="Upscaled image with color correction applied. Format (RGB/RGBA) matches input. Range [0, 1] normalized for ComfyUI compatibility."
+                )
+            ]
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        image: torch.Tensor,
+        dit: dict[str, Any],
+        vae: dict[str, Any],
+        seed: int = 42,
+        resolution: int = 1080,
+        tile_size: int = 512,
+        mask_blur: int = 0,
+        tile_overlap: int = 32,
+        tile_upscale_resolution: int = 0,
+        tiling_strategy: str = "Linear",
+        anti_aliasing_strength: float = 0.0,
+        blending_method: str = "auto",
+        color_correction: str = "wavelet",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "none",
+        enable_debug: bool = False,
+    ) -> io.NodeOutput:
+        progress: Progress | None = None
+        tile_upscale_resolution = int(tile_upscale_resolution)
+
+        try:
+            start_time = time.perf_counter()
+            pil_image = ImageUtils.tensor_to_pil(image)
+            upscale_factor = resolution / min(pil_image.width, pil_image.height)
+            output_width = int(pil_image.width * upscale_factor)
+            output_height = int(pil_image.height * upscale_factor)
+            resolved_tile_upscale_resolution = SeedVR2ImageUpscaler._resolve_tile_upscale_resolution(
+                tile_upscale_resolution, tile_size, upscale_factor
+            )
+
+            main_tiles = TileUtils.generate_tiles(pil_image, tile_size, tile_overlap, tiling_strategy)
+            progress = Progress(len(main_tiles), enable_debug=enable_debug)
+            progress.initialize_websocket_progress()
+
+            Logger.log(
+                f"Input={pil_image.width}x{pil_image.height}, Output={output_width}x{output_height}, "
+                f"Tiles={len(main_tiles)}, TileSize={tile_size}x{tile_size}, "
+                f"Overlap={tile_overlap}, Strategy={tiling_strategy}, Blend={blending_method}, "
+                f"TileUpscale={resolved_tile_upscale_resolution}"
+                f"{' (auto)' if tile_upscale_resolution <= 0 else ''}, "
+                f"InputNoise={input_noise_scale:.4f}, Offload={offload_device}"
+            )
+    
+            output_image = StitchingPipeline.process_and_stitch(
+                tiles=main_tiles,
+                width=output_width,
+                height=output_height,
+                dit_config=dit,
+                vae_config=vae,
+                seed=seed,
+                tile_upscale_resolution=resolved_tile_upscale_resolution,
+                upscale_factor=upscale_factor,
+                mask_blur=mask_blur,
+                progress=progress,
+                original_image=pil_image,
+                anti_aliasing_strength=anti_aliasing_strength,
+                blending_method=blending_method,
+                color_correction=color_correction,
+                input_noise_scale=input_noise_scale,
+                offload_device=offload_device,
+                enable_debug=enable_debug,
+            )
+
+            progress.finalize_websocket_progress()
+            Logger.log(f"Completed tiling upscale in {time.perf_counter() - start_time:.2f}s")
+
+            return (ImageUtils.pil_to_tensor(output_image),)
+
+        except Exception as e:
+            if progress is not None:
+                progress.finalize_websocket_progress()
+            raise e
+
+    @staticmethod
+    def _get_device_list(include_none: bool = False, include_cpu: bool = False) -> list[str]:
+        devs = []
+        has_cuda = False
+        has_mps = False
+
+        try:
+            if torch.cuda.is_available():
+                devs += [f"cuda:{i}" for i in range(torch.cuda.device_count())]
+                has_cuda = True
+        except Exception:
+            pass
+
+        try:
+            if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+                devs.append("mps")
+                has_mps = True
+        except Exception:
+            pass
+        
+        result = []
+        if include_none:
+            result.append("none")
+
+        if include_cpu and (has_cuda or not has_mps):
+            result.append("cpu")
+
+        result.extend(devs)
+        
+        return result if result else []
+
+    @staticmethod
+    def _resolve_tile_upscale_resolution(tile_upscale_resolution: int, tile_size: int, upscale_factor: float) -> int:
+        min_resolution = 64
+        max_resolution = 8192
+        step = 8
+
+        if tile_upscale_resolution <= 0:
+            tile_upscale_resolution = int(round(tile_size * upscale_factor))
+
+        tile_upscale_resolution = max(min_resolution, min(max_resolution, tile_upscale_resolution))
+        tile_upscale_resolution = int(round(tile_upscale_resolution / step) * step)
+
+        return max(min_resolution, min(max_resolution, tile_upscale_resolution))

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/image_utils.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/image_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import torch
+import numpy as np
+from PIL import Image
+
+
+class ImageUtils:
+    @staticmethod
+    def tensor_to_pil(tensor: torch.Tensor) -> Image.Image:
+        """Convert a tensor to PIL Image.
+
+        Args:
+            tensor: Input tensor with shape (1, H, W, C) or (H, W, C)
+
+        Returns:
+            PIL Image in RGB mode
+        """
+        # Only squeeze the batch dimension (dim 0), not all dimensions
+        # This prevents accidentally removing spatial dimensions of size 1
+        if tensor.dim() == 4:
+            tensor = tensor.squeeze(0)  # Remove batch dimension only: (1, H, W, C) -> (H, W, C)
+        image_np = tensor.mul(255).clamp(0, 255).byte().numpy()
+        return Image.fromarray(image_np, "RGB")
+        
+    @staticmethod
+    def pil_to_tensor(image: Image.Image) -> torch.Tensor:
+        return torch.from_numpy(np.array(image).astype(np.float32) / 255.0).unsqueeze(0)

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/logger.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/logger.py
@@ -1,0 +1,4 @@
+class Logger:
+    @staticmethod
+    def log(msg: str) -> None:
+        print(f"[SeedVR2 Tiling] {msg}", flush=True)

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/progress.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/progress.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from comfy.utils import ProgressBar
+from .logger import Logger
+
+class Progress:
+    def __init__(self, total_steps: int, sub_steps_per_tile: int = 3, enable_debug: bool = False) -> None:
+        self.total_steps = max(int(total_steps), 0)
+        self.sub_steps_per_tile = max(int(sub_steps_per_tile), 1)
+        self.total_sub_steps = max(self.total_steps * self.sub_steps_per_tile, 1)
+        self.current_step = 0
+        self.current_sub_step = 0
+        self.enable_debug = enable_debug
+        self._last_percent = -1
+        self._progress_bar = ProgressBar(100)
+
+        Logger.log(f"Starting upscale process: tiles={self.total_steps}")
+        self._emit_progress(force=True)
+
+    def update(self, sub_progress_step: int | None = None) -> None:
+        step = 0
+
+        if sub_progress_step is not None:
+            step = max(0, min(int(sub_progress_step), self.sub_steps_per_tile))
+        else:
+            self.current_step = min(self.total_steps, self.current_step + 1)
+
+        self.current_sub_step = min(
+            self.total_sub_steps,
+            self.current_step * self.sub_steps_per_tile + step,
+        )
+
+        if self.enable_debug:
+            Logger.log(
+                f"[debug] Progress: tile={self.current_step}/{self.total_steps}, step={self.current_sub_step}/{self.total_sub_steps}"
+            )
+
+        self._emit_progress()
+
+    def update_sub_progress(self, step_name: str, step_number: int) -> None:
+        step = max(0, min(int(step_number), self.sub_steps_per_tile))
+        self.current_sub_step = min(
+            self.total_sub_steps,
+            self.current_step * self.sub_steps_per_tile + step,
+        )
+
+        if self.enable_debug:
+            Logger.log(
+                f"[debug] {step_name}, tile={self.current_step}/{self.total_steps}, step={step}/{self.sub_steps_per_tile}"
+            )
+
+        self._emit_progress()
+
+    def initialize_websocket_progress(self) -> None:
+        self.current_step = 0
+        self.current_sub_step = 0
+        self._emit_progress(force=True)
+
+    def finalize_websocket_progress(self) -> None:
+        self.current_step = self.total_steps
+        self.current_sub_step = self.total_sub_steps
+        self._emit_progress(force=True)
+        Logger.log(f"Upscale completed successfully: tiles={self.total_steps}")
+
+    def _emit_progress(self, force: bool = False) -> None:
+        percent = int((self.current_sub_step / self.total_sub_steps) * 100)
+        percent = max(0, min(100, percent))
+
+        if not force and percent == self._last_percent:
+            return
+
+        self._last_percent = percent
+        self._progress_bar.update_absolute(percent, 100)

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/seedvr2_adapter.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/seedvr2_adapter.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING, Literal
+from .logger import Logger
+
+if TYPE_CHECKING:
+    from src.interfaces.video_upscaler import SeedVR2VideoUpscaler
+
+
+class SeedVR2Adapter:
+    @staticmethod
+    def get_upscaler_class() -> type["SeedVR2VideoUpscaler"]:
+        import nodes
+
+        for node_class in nodes.NODE_CLASS_MAPPINGS.values():
+            if getattr(node_class, "__name__", "") == "SeedVR2VideoUpscaler":
+                return node_class
+
+        raise RuntimeError(
+            "SeedVR2VideoUpscaler node not found. "
+            "Please install ComfyUI-SeedVR2_VideoUpscaler v2.5 or later."
+        )
+
+    @staticmethod
+    def execute_seedvr2(
+        *,
+        images: torch.Tensor,
+        dit_config: dict[str, object],
+        vae_config: dict[str, object],
+        seed: int,
+        resolution: int = 1080,
+        batch_size: int = 1,
+        color_correction: Literal["lab", "wavelet", "wavelet_adaptive", "hsv", "adain", None] = "wavelet",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "none",
+        enable_debug: bool = False,
+    ) -> torch.Tensor:
+        """Execute SeedVR2 upscaling on a batch of images.
+
+        Args:
+            images: Input images tensor (N, H, W, C) in [0, 1] range
+            dit_config: DiT model configuration from SeedVR2LoadDiTModel node
+            vae_config: VAE model configuration from SeedVR2LoadVAEModel node
+            seed: Random seed for reproducibility
+            resolution: Target resolution for the shortest edge
+            batch_size: Number of frames to process together
+            color_correction: Color correction method
+            input_noise_scale: Input noise injection scale [0.0-1.0]
+            offload_device: Device to offload intermediate tensors
+            enable_debug: Enable upstream debug logging
+
+        Returns:
+            Upscaled images tensor (N, H', W', C) in [0, 1] range
+        """
+        if enable_debug:
+            Logger.log(
+                f"[debug] Invoking SeedVR2VideoUpscaler: batch_size={batch_size}, resolution={resolution}, "
+                f"input_noise_scale={input_noise_scale:.2f}, offload_device={offload_device}"
+            )
+
+        result = SeedVR2Adapter.get_upscaler_class().execute(
+            image=images,
+            dit=dit_config,
+            vae=vae_config,
+            seed=seed,
+            resolution=resolution,
+            batch_size=batch_size,
+            color_correction=color_correction,
+            input_noise_scale=input_noise_scale,
+            offload_device=offload_device,
+            enable_debug=enable_debug,
+        )
+
+        if hasattr(result, "values"):
+            return result.values[0] if isinstance(result.values, (list, tuple)) else result.values
+        elif hasattr(result, "__getitem__"):
+            return result[0]
+
+        return result

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/stitching.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/stitching.py
@@ -1,0 +1,1285 @@
+"""Stitching algorithms for blending upscaled tiles."""
+
+from __future__ import annotations
+
+import time
+
+import torch
+import numpy as np
+from PIL import Image
+from scipy import ndimage
+from collections import defaultdict
+from typing import Any
+from .logger import Logger
+
+try:
+    import cv2
+    HAS_OPENCV = True
+except ImportError:
+    HAS_OPENCV = False
+    print("Warning: OpenCV not available. Bilateral filtering will use Gaussian approximation.")
+
+from .image_utils import ImageUtils
+from .seedvr2_adapter import SeedVR2Adapter
+
+
+class StitchingPipeline:
+    @staticmethod
+    def _align_resolution(resolution: int, min_resolution: int = 256, max_resolution: int = 4096, step: int = 32) -> int:
+        """Clamp and align a resolution value to model-friendly multiples."""
+        resolution = max(min_resolution, min(max_resolution, int(resolution)))
+        return int(round(resolution / step) * step)
+
+    @staticmethod
+    def _resolve_group_upscale_resolution(
+        tile_size: tuple[int, int],
+        upscale_factor: float,
+        fallback_resolution: int,
+    ) -> int:
+        """Derive target resolution from tile dimensions for scale-consistent group processing."""
+        if upscale_factor <= 0:
+            return StitchingPipeline._align_resolution(fallback_resolution)
+        target = int(round(min(tile_size) * upscale_factor))
+        if target <= 0:
+            target = int(fallback_resolution)
+        return StitchingPipeline._align_resolution(target)
+
+    @staticmethod
+    def _edge_distance_map(height: int, width: int) -> np.ndarray:
+        """Distance from each pixel to the closest tile edge."""
+        if height <= 0 or width <= 0:
+            return np.zeros((0, 0), dtype=np.float32)
+        x = np.arange(width, dtype=np.float32)
+        y = np.arange(height, dtype=np.float32)
+        dist_x = np.minimum(x, width - 1 - x)
+        dist_y = np.minimum(y, height - 1 - y)
+        return np.minimum(dist_y[:, np.newaxis], dist_x[np.newaxis, :]).astype(np.float32)
+
+    @staticmethod
+    def _edge_weight_map(height: int, width: int, min_weight: float = 0.1) -> np.ndarray:
+        """Edge-distance weights for blending."""
+        if height <= 0 or width <= 0:
+            return np.zeros((0, 0), dtype=np.float32)
+        dist = StitchingPipeline._edge_distance_map(height, width)
+        denom = float(max(height, width))
+        if denom <= 0:
+            return np.full((height, width), min_weight, dtype=np.float32)
+        return np.maximum(min_weight, dist / denom).astype(np.float32)
+
+    @staticmethod
+    def _blend_weighted_region(
+        output_region: np.ndarray,
+        weight_region: np.ndarray,
+        tile_region: np.ndarray,
+        tile_weight: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Blend a tile region into output using per-pixel weights."""
+        new_weight = weight_region + tile_weight
+        safe_weight = np.maximum(new_weight, 1e-8)
+        blended = (
+            output_region * weight_region[:, :, np.newaxis]
+            + tile_region * tile_weight[:, :, np.newaxis]
+        ) / safe_weight[:, :, np.newaxis]
+
+        empty_mask = weight_region <= 0
+        if np.any(empty_mask):
+            blended[empty_mask] = tile_region[empty_mask]
+
+        return blended, new_weight
+
+    @staticmethod
+    def _get_optimal_batch_size(num_tiles: int) -> int:
+        """Calculate optimal batch size following 4n+1 pattern (1, 5, 9, 13, 17, 21...)"""
+        if num_tiles <= 1:
+            return 1
+        # Find largest 4n+1 that doesn't exceed num_tiles
+        n = (num_tiles - 1) // 4
+        return 4 * n + 1
+
+
+    @staticmethod
+    def _create_base_image(
+        original_image: Image.Image,
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+    ) -> Image.Image:
+        """Create base image for stitching by upscaling the original at low resolution."""
+        base_resolution = min(512, tile_upscale_resolution // 2)
+        Logger.log(f"Creating base image: resolution={base_resolution}, offload_device={offload_device}")
+
+        base_tensor = ImageUtils.pil_to_tensor(original_image)
+        base_upscaled = SeedVR2Adapter.execute_seedvr2(
+            images=base_tensor,
+            dit_config=dit_config,
+            vae_config=vae_config,
+            seed=seed,
+            resolution=base_resolution,
+            batch_size=1,
+            color_correction=color_correction,
+            input_noise_scale=input_noise_scale,
+            offload_device=offload_device,
+            enable_debug=enable_debug,
+        )
+        base_pil = ImageUtils.tensor_to_pil(base_upscaled)
+        return base_pil.resize((width, height), Image.LANCZOS)
+
+
+    @staticmethod
+    def _batch_upscale_tiles(
+        tiles: list[dict[str, object]],
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float | None = None,
+        progress: Any | None = None,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+    ) -> list[Image.Image]:
+        """Batch process tiles by grouping them by size for optimal performance.
+
+        Per-tile color correction is intentionally disabled here (see the call to
+        execute_seedvr2 below): each tile-batch would otherwise be color-matched
+        independently against only its own local crop, so tiles with different
+        content (e.g. skin vs. background) drift to different color statistics and
+        show up as a visible seam once stitched. Color correction against a single,
+        globally-consistent reference is applied once at the end of
+        process_and_stitch instead.
+        """
+        # Group tiles by their dimensions
+        tiles_by_size = defaultdict(list)
+        for idx, tile_info in enumerate(tiles):
+            tile_size = (tile_info["tile"].width, tile_info["tile"].height)
+            tiles_by_size[tile_size].append((idx, tile_info))
+
+        # Process each size group with optimal batch sizes
+        upscaled_tiles = [None] * len(tiles)
+        tiles_processed_count = 0
+
+        for tile_size, tile_group in tiles_by_size.items():
+            num_tiles_in_group = len(tile_group)
+            group_resolution = tile_upscale_resolution
+            if upscale_factor is not None:
+                group_resolution = StitchingPipeline._resolve_group_upscale_resolution(
+                    tile_size,
+                    float(upscale_factor),
+                    int(tile_upscale_resolution),
+                )
+            processed_tiles = 0
+            Logger.log(
+                f"Tile group {tile_size[0]}x{tile_size[1]}, count={num_tiles_in_group}, "
+                f"resolution={group_resolution}"
+            )
+            group_indices: list[int] = []
+            group_tensor_batches: list[torch.Tensor] = []
+
+            # Process this size group in optimal sub-batches
+            while processed_tiles < num_tiles_in_group:
+                remaining = num_tiles_in_group - processed_tiles
+                batch_size = StitchingPipeline._get_optimal_batch_size(remaining)
+                Logger.log(f"Upscaling sub-batch: size={batch_size}, remaining={remaining}")
+
+                # Get tiles for this sub-batch
+                sub_batch = tile_group[processed_tiles:processed_tiles + batch_size]
+
+                # Collect tensors for this sub-batch
+                tile_tensors = [ImageUtils.pil_to_tensor(tile_info["tile"]) for _, tile_info in sub_batch]
+                batch_tensor = torch.cat(tile_tensors, dim=0)
+
+                # Update progress before processing
+                if progress:
+                    progress.update_sub_progress(f"AI Upscaling ({tiles_processed_count + 1}/{len(tiles)})", 1)
+
+                # Process this sub-batch
+                upscaled_batch = SeedVR2Adapter.execute_seedvr2(
+                    images=batch_tensor,
+                    dit_config=dit_config,
+                    vae_config=vae_config,
+                    seed=seed,
+                    resolution=group_resolution,
+                    batch_size=batch_size,
+                    color_correction=None,
+                    input_noise_scale=input_noise_scale,
+                    offload_device=offload_device,
+                    enable_debug=enable_debug,
+                )
+
+                # Keep tensors and convert once per size-group.
+                group_tensor_batches.append(upscaled_batch.detach().cpu())
+                for original_idx, _ in sub_batch:
+                    group_indices.append(original_idx)
+                    tiles_processed_count += 1
+                    # Update progress after each tile
+                    if progress:
+                        progress.update_sub_progress(f"AI Upscaling ({tiles_processed_count}/{len(tiles)})", 1)
+
+                processed_tiles += batch_size
+
+            if group_tensor_batches:
+                group_tensor = torch.cat(group_tensor_batches, dim=0)
+                group_uint8 = group_tensor.mul(255).clamp(0, 255).byte().numpy()
+                for group_idx, original_idx in enumerate(group_indices):
+                    upscaled_tiles[original_idx] = Image.fromarray(group_uint8[group_idx], "RGB")
+
+        return upscaled_tiles
+
+
+    @staticmethod
+    def _prepare_tile_for_stitching(
+        tile_info: dict[str, object],
+        ai_upscaled_tile: Image.Image,
+        upscale_factor: float,
+    ) -> dict[str, object]:
+        """Prepare an upscaled tile for stitching by resizing, positioning, and cropping.
+
+        This function handles both regular overlap padding (for blending adjacent tiles)
+        and memory padding (added for GPU efficiency). Memory padding must be completely
+        removed as it contains reflected/extended content that shouldn't be in the output.
+        """
+        # Get the original tile size (before memory padding was added)
+        original_width, original_height = tile_info["original_tile_size"]
+
+        # The AI upscaled the full tile (including memory padding)
+        # We need to first crop out the memory padding, then handle overlap padding
+
+        # Get memory padding info
+        mem_left_pad, mem_top_pad, mem_right_pad, mem_bottom_pad = tile_info.get("memory_padding", (0, 0, 0, 0))
+
+        # Calculate the upscaled dimensions
+        # The upscaled tile corresponds to the full padded tile (with memory padding)
+        full_tile_width = tile_info["tile"].width
+        full_tile_height = tile_info["tile"].height
+
+        # Resize the upscaled tile to match the expected output size for the full tile
+        target_full_width = int(full_tile_width * upscale_factor)
+        target_full_height = int(full_tile_height * upscale_factor)
+        if ai_upscaled_tile.size == (target_full_width, target_full_height):
+            resized_tile = ai_upscaled_tile
+        else:
+            resized_tile = ai_upscaled_tile.resize((target_full_width, target_full_height), Image.LANCZOS)
+
+        # First, crop out the memory padding (scale the memory padding amounts)
+        scaled_mem_right = int(mem_right_pad * upscale_factor)
+        scaled_mem_bottom = int(mem_bottom_pad * upscale_factor)
+
+        # The original content (without memory padding) is in the top-left portion
+        original_content_width = int(original_width * upscale_factor)
+        original_content_height = int(original_height * upscale_factor)
+
+        # Crop to remove memory padding - keep only the original content area
+        if scaled_mem_right > 0 or scaled_mem_bottom > 0:
+            resized_tile = resized_tile.crop((0, 0, original_content_width, original_content_height))
+
+        # Now handle the regular overlap padding for blending
+        # Calculate positioning
+        paste_x = int(tile_info["position"][0] * upscale_factor)
+        paste_y = int(tile_info["position"][1] * upscale_factor)
+        final_tile_width = int(tile_info["actual_size"][0] * upscale_factor)
+        final_tile_height = int(tile_info["actual_size"][1] * upscale_factor)
+
+        # Calculate scaled overlap padding
+        left_pad, top_pad, right_pad, bottom_pad = tile_info["padding"]
+
+        scaled_left_pad = int(left_pad * upscale_factor)
+        scaled_top_pad = int(top_pad * upscale_factor)
+        scaled_right_pad = int(right_pad * upscale_factor)
+        scaled_bottom_pad = int(bottom_pad * upscale_factor)
+
+        # Keep half the padding on ALL sides to create overlap for blending
+        keep_left = scaled_left_pad // 2 if left_pad > 0 else 0
+        keep_top = scaled_top_pad // 2 if top_pad > 0 else 0
+        keep_right = scaled_right_pad // 2 if right_pad > 0 else 0
+        keep_bottom = scaled_bottom_pad // 2 if bottom_pad > 0 else 0
+
+        # Crop the tile - keep partial overlap padding on all sides for blending
+        crop_box = (
+            scaled_left_pad - keep_left,
+            scaled_top_pad - keep_top,
+            min(scaled_left_pad + final_tile_width + keep_right, resized_tile.width),
+            min(scaled_top_pad + final_tile_height + keep_bottom, resized_tile.height)
+        )
+        cropped_tile = resized_tile.crop(crop_box)
+
+        # Adjust paste position to account for kept left/top padding
+        paste_x_adjusted = max(0, paste_x - keep_left)
+        paste_y_adjusted = max(0, paste_y - keep_top)
+
+        return {
+            "cropped_tile": cropped_tile,
+            "paste_x": paste_x_adjusted,
+            "paste_y": paste_y_adjusted,
+            "keep_padding": (keep_left, keep_top, keep_right, keep_bottom),
+        }
+
+
+    @staticmethod
+    def _build_laplacian_pyramid(image: np.ndarray, levels: int = 4) -> list[np.ndarray]:
+        """Build a Laplacian pyramid for multi-band blending.
+
+        Args:
+            image: numpy array (H, W, C)
+            levels: number of pyramid levels
+
+        Returns:
+            List of Laplacian pyramid levels (finest to coarsest)
+        """
+        gaussian_pyramid = [image.astype(np.float32)]
+
+        # Build Gaussian pyramid
+        for i in range(levels):
+            down = ndimage.zoom(gaussian_pyramid[-1], (0.5, 0.5, 1), order=1)
+            gaussian_pyramid.append(down)
+
+        # Build Laplacian pyramid
+        laplacian_pyramid = []
+        for i in range(levels):
+            # Upscale the next level
+            size = gaussian_pyramid[i].shape
+            upscaled = ndimage.zoom(gaussian_pyramid[i + 1],
+                                (size[0] / gaussian_pyramid[i + 1].shape[0],
+                                    size[1] / gaussian_pyramid[i + 1].shape[1],
+                                    1), order=1)
+            # Laplacian = Gaussian - upscaled(next_gaussian)
+            laplacian = gaussian_pyramid[i] - upscaled
+            laplacian_pyramid.append(laplacian)
+
+        # Add the smallest Gaussian as the last level
+        laplacian_pyramid.append(gaussian_pyramid[-1])
+
+        return laplacian_pyramid
+
+
+    @staticmethod
+    def _collapse_laplacian_pyramid(laplacian_pyramid: list[np.ndarray]) -> np.ndarray:
+        """Collapse a Laplacian pyramid back to an image.
+
+        Args:
+            laplacian_pyramid: List of Laplacian levels (finest to coarsest)
+
+        Returns:
+            Reconstructed image as numpy array
+        """
+        # Start with the coarsest level
+        image = laplacian_pyramid[-1]
+
+        # Reconstruct from coarse to fine
+        for i in range(len(laplacian_pyramid) - 2, -1, -1):
+            # Upscale current image to match next level size
+            size = laplacian_pyramid[i].shape
+            upscaled = ndimage.zoom(image,
+                                (size[0] / image.shape[0],
+                                    size[1] / image.shape[1],
+                                    1), order=1)
+            # Add the Laplacian details
+            image = upscaled + laplacian_pyramid[i]
+
+        return image
+
+
+    @staticmethod
+    def _apply_bilateral_filter(
+        image: Image.Image | np.ndarray,
+        d: int = 9,
+        sigma_color: float = 75,
+        sigma_space: float = 75,
+    ) -> np.ndarray:
+        """Apply bilateral filtering for edge-preserving smoothing.
+
+        Args:
+            image: PIL Image or numpy array
+            d: Diameter of pixel neighborhood
+            sigma_color: Filter sigma in color space
+            sigma_space: Filter sigma in coordinate space
+
+        Returns:
+            Filtered image as numpy array
+        """
+        if isinstance(image, Image.Image):
+            img_array = np.array(image)
+        else:
+            img_array = image
+
+        if HAS_OPENCV:
+            # Use OpenCV's optimized bilateral filter
+            filtered = cv2.bilateralFilter(img_array, d, sigma_color, sigma_space)
+        else:
+            # Fallback: Use Gaussian approximation
+            filtered = img_array.astype(np.float32)
+
+            # Apply edge-aware smoothing using gradients
+            for channel in range(3):
+                channel_data = filtered[:, :, channel]
+
+                # Detect edges
+                sobel_x = ndimage.sobel(channel_data, axis=1)
+                sobel_y = ndimage.sobel(channel_data, axis=0)
+                edge_magnitude = np.sqrt(sobel_x**2 + sobel_y**2)
+
+                # Normalize and invert (smooth where no edges)
+                if edge_magnitude.max() > 0:
+                    edge_magnitude = edge_magnitude / edge_magnitude.max()
+                smoothing_weight = 1.0 - edge_magnitude
+
+                # Apply adaptive Gaussian smoothing
+                smoothed = ndimage.gaussian_filter(channel_data, sigma=sigma_space / 10.0)
+                filtered[:, :, channel] = channel_data * edge_magnitude + smoothed * smoothing_weight
+
+            filtered = np.clip(filtered, 0, 255).astype(np.uint8)
+
+        return filtered
+
+
+    @staticmethod
+    def _compute_structure_tensor(image: np.ndarray, sigma: float = 1.5) -> tuple[np.ndarray, np.ndarray]:
+        """Compute structure tensor for content-aware blending.
+
+        Args:
+            image: numpy array (H, W, C)
+            sigma: Gaussian smoothing sigma for structure tensor
+
+        Returns:
+            edge_strength: Edge strength map (H, W)
+            coherence: Local structure coherence (H, W)
+        """
+        # Convert to grayscale for structure analysis
+        if len(image.shape) == 3:
+            gray = np.mean(image, axis=2)
+        else:
+            gray = image
+
+        # Compute gradients
+        Ix = ndimage.sobel(gray, axis=1)
+        Iy = ndimage.sobel(gray, axis=0)
+
+        # Compute structure tensor components
+        Ixx = ndimage.gaussian_filter(Ix * Ix, sigma)
+        Iyy = ndimage.gaussian_filter(Iy * Iy, sigma)
+        Ixy = ndimage.gaussian_filter(Ix * Iy, sigma)
+
+        # Compute eigenvalues for edge strength and coherence
+        trace = Ixx + Iyy
+        det = Ixx * Iyy - Ixy * Ixy
+
+        # Eigenvalues: lambda = (trace ± sqrt(trace^2 - 4*det)) / 2
+        discriminant = np.maximum(trace * trace - 4 * det, 0)
+        lambda1 = (trace + np.sqrt(discriminant)) / 2
+        lambda2 = (trace - np.sqrt(discriminant)) / 2
+
+        # Edge strength (larger eigenvalue)
+        edge_strength = lambda1
+
+        # Coherence (anisotropy measure)
+        coherence = np.zeros_like(trace)
+        mask = lambda1 > 1e-5
+        coherence[mask] = (lambda1[mask] - lambda2[mask]) / (lambda1[mask] + lambda2[mask])
+
+        # Normalize
+        if edge_strength.max() > 0:
+            edge_strength = edge_strength / edge_strength.max()
+        coherence = np.clip(coherence, 0, 1)
+
+        return edge_strength, coherence
+
+
+    @staticmethod
+    def process_and_stitch(
+        tiles: list[dict[str, object]],
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float,
+        mask_blur: int,
+        progress,
+        original_image: Image.Image,
+        anti_aliasing_strength: float = 0.0,
+        blending_method: str = "auto",
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+    ) -> Image.Image:
+        """Main stitching function that chooses the appropriate method based on settings.
+
+        Args:
+            tiles: List of tile info dictionaries
+            width: Output image width
+            height: Output image height
+            dit_config: DiT model configuration
+            vae_config: VAE model configuration
+            seed: Random seed
+            tile_upscale_resolution: Resolution for upscaling tiles
+            upscale_factor: Scale factor for output
+            mask_blur: Blur radius for mask blending
+            progress: Progress tracker
+            original_image: Original input image
+            anti_aliasing_strength: Anti-aliasing strength (0-1)
+            blending_method: Blending method to use
+            color_correction: Color correction method for SeedVR2
+            input_noise_scale: Input noise injection scale [0.0-1.0]
+            offload_device: Device to offload intermediate tensors
+            enable_debug: Enable extension-specific debug logs
+
+        Returns:
+            Stitched output image
+        """
+        stitch_start = time.perf_counter()
+
+        # Auto mode: choose based on mask_blur value
+        if blending_method == "auto":
+            if mask_blur == 0:
+                blending_method = "simple"
+            elif mask_blur <= 2:
+                blending_method = "linear"
+            else:
+                blending_method = "linear"
+
+        print(f"[SeedVR2 Tiling] Using {blending_method} blending method...", flush=True)
+        Logger.log(
+            f"Stitching setup: tiles={len(tiles)}, output={width}x{height}, "
+            f"tile_upscale_resolution={tile_upscale_resolution}, input_noise_scale={input_noise_scale:.4f}, "
+            f"offload_device={offload_device}"
+        )
+
+        # Common kwargs for all blending methods
+        kwargs = {
+            "tiles": tiles,
+            "width": width,
+            "height": height,
+            "dit_config": dit_config,
+            "vae_config": vae_config,
+            "seed": seed,
+            "tile_upscale_resolution": tile_upscale_resolution,
+            "upscale_factor": upscale_factor,
+            "progress": progress,
+            "original_image": original_image,
+            "color_correction": color_correction,
+            "input_noise_scale": input_noise_scale,
+            "offload_device": offload_device,
+            "enable_debug": enable_debug,
+        }
+
+        # Route to appropriate blending function
+        if blending_method == "multiband":
+            result = StitchingPipeline._process_and_stitch_multiband(**kwargs)
+        elif blending_method == "bilateral":
+            result = StitchingPipeline._process_and_stitch_bilateral(**kwargs, mask_blur=mask_blur)
+        elif blending_method == "content_aware":
+            result = StitchingPipeline._process_and_stitch_content_aware(**kwargs, mask_blur=mask_blur)
+        elif blending_method == "simple":
+            result = StitchingPipeline._process_and_stitch_zero_blur(**kwargs)
+        else:  # "linear" or default
+            result = StitchingPipeline._process_and_stitch_blended(**kwargs, mask_blur=mask_blur)
+
+        # Harmonize color across tile seams. Tiles are upscaled with per-tile
+        # color correction disabled (see _batch_upscale_tiles) because matching
+        # each tile against only its own local crop makes tiles with different
+        # content (e.g. skin vs. background) drift to different color statistics,
+        # producing a visible seam once stitched. Apply the requested correction
+        # once instead, globally, against a single low-resolution reference
+        # upscale of the whole image.
+        if color_correction != "none":
+            reference = StitchingPipeline._create_base_image(
+                original_image,
+                width,
+                height,
+                dit_config,
+                vae_config,
+                seed,
+                tile_upscale_resolution,
+                color_correction,
+                input_noise_scale,
+                offload_device,
+                enable_debug,
+            )
+            result = StitchingPipeline._match_color_lab(result, reference)
+
+        # Apply anti-aliasing if requested
+        if anti_aliasing_strength > 0:
+            result = StitchingPipeline._apply_edge_aware_antialiasing(result, anti_aliasing_strength)
+
+        Logger.log(f"Stitching complete in {time.perf_counter() - stitch_start:.2f}s")
+
+        return result
+
+
+    @staticmethod
+    def _apply_edge_aware_antialiasing(image: Image.Image, strength: float) -> Image.Image:
+        """Apply edge-aware anti-aliasing using Sobel edge detection."""
+        img_array = np.array(image, dtype=np.float32)
+        smoothed = np.zeros_like(img_array)
+
+        for channel in range(3):
+            channel_data = img_array[:, :, channel]
+
+            # Apply Sobel filters to detect edges
+            sobel_x = ndimage.sobel(channel_data, axis=1)
+            sobel_y = ndimage.sobel(channel_data, axis=0)
+
+            # Calculate edge magnitude
+            edge_magnitude = np.sqrt(sobel_x**2 + sobel_y**2)
+
+            # Normalize edge magnitude to 0-1
+            if edge_magnitude.max() > 0:
+                edge_magnitude = edge_magnitude / edge_magnitude.max()
+
+            # Create inverse edge map
+            smoothing_mask = 1.0 - edge_magnitude
+            smoothing_mask = 1.0 - (smoothing_mask * strength)
+
+            # Apply Gaussian smoothing
+            sigma = 0.5 + (strength * 1.5)
+            smoothed_channel = ndimage.gaussian_filter(channel_data, sigma=sigma)
+
+            # Selective blend
+            smoothed[:, :, channel] = channel_data * smoothing_mask + smoothed_channel * (1.0 - smoothing_mask)
+
+        smoothed = np.clip(smoothed, 0, 255).astype(np.uint8)
+        return Image.fromarray(smoothed)
+
+
+    @staticmethod
+    def _match_color_lab(image: Image.Image, reference: Image.Image) -> Image.Image:
+        """Match image's color statistics to reference in LAB space (Reinhard et al. 2001).
+
+        Used as a single global color-harmonization pass after stitching, so every
+        tile ends up graded against the same reference instead of each tile's own
+        (independently drifting) local crop.
+        """
+        if not HAS_OPENCV:
+            return image
+
+        src = np.array(image.convert("RGB"), dtype=np.float32) / 255.0
+        ref = reference.convert("RGB")
+        if ref.size != image.size:
+            ref = ref.resize(image.size, Image.LANCZOS)
+        ref_arr = np.array(ref, dtype=np.float32) / 255.0
+
+        src_lab = cv2.cvtColor(src, cv2.COLOR_RGB2LAB)
+        ref_lab = cv2.cvtColor(ref_arr, cv2.COLOR_RGB2LAB)
+
+        matched_lab = np.empty_like(src_lab)
+        for channel in range(3):
+            src_channel = src_lab[:, :, channel]
+            ref_channel = ref_lab[:, :, channel]
+            src_std = max(float(src_channel.std()), 1e-6)
+            matched_lab[:, :, channel] = (
+                (src_channel - src_channel.mean()) * (ref_channel.std() / src_std) + ref_channel.mean()
+            )
+
+        matched_rgb = cv2.cvtColor(matched_lab, cv2.COLOR_LAB2RGB)
+        matched_rgb = np.clip(matched_rgb * 255.0, 0, 255).astype(np.uint8)
+        return Image.fromarray(matched_rgb)
+
+
+    @staticmethod
+    def _process_and_stitch_multiband(
+        tiles: list[dict[str, object]],
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float,
+        progress,
+        original_image: Image.Image,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+    ) -> Image.Image:
+        """Multi-band blending using Laplacian pyramids for frequency-separated stitching."""
+        # Create base image
+        base_image = StitchingPipeline._create_base_image(
+            original_image,
+            width,
+            height,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        # Batch process and upscale tiles
+        upscaled_tiles = StitchingPipeline._batch_upscale_tiles(
+            tiles,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            upscale_factor,
+            progress,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        # Build Laplacian pyramid for base image
+        base_array = np.array(base_image, dtype=np.float32)
+        pyramid_levels = 4
+        output_pyramid = StitchingPipeline._build_laplacian_pyramid(base_array, pyramid_levels)
+
+        # Process each tile and blend into pyramid
+        for tile_idx, tile_info in enumerate(tiles):
+            ai_upscaled_tile = upscaled_tiles[tile_idx]
+
+            progress.update_sub_progress("Resizing & Positioning", 2)
+            prepared = StitchingPipeline._prepare_tile_for_stitching(tile_info, ai_upscaled_tile, upscale_factor)
+            cropped_tile = prepared["cropped_tile"]
+            paste_x_adjusted = prepared["paste_x"]
+            paste_y_adjusted = prepared["paste_y"]
+
+            progress.update_sub_progress("Multi-band Blending", 3)
+
+            # Build Laplacian pyramid for this tile
+            tile_array = np.array(cropped_tile, dtype=np.float32)
+
+            # Create full-size tile array
+            full_tile_array = np.zeros((height, width, 3), dtype=np.float32)
+            end_x = min(paste_x_adjusted + tile_array.shape[1], width)
+            end_y = min(paste_y_adjusted + tile_array.shape[0], height)
+
+            tile_height = end_y - paste_y_adjusted
+            tile_width = end_x - paste_x_adjusted
+            full_tile_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = tile_array[:tile_height, :tile_width]
+
+            # Build pyramid for this tile
+            tile_pyramid = StitchingPipeline._build_laplacian_pyramid(full_tile_array, pyramid_levels)
+
+            # Create blending mask
+            mask = np.zeros((height, width), dtype=np.float32)
+            mask[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = 1.0
+
+            # Apply feathering to mask based on overlap
+            feather_size = min(32, tile_width // 4, tile_height // 4)
+            if feather_size > 0:
+                local_mask = np.minimum(
+                    1.0,
+                    StitchingPipeline._edge_distance_map(tile_height, tile_width) / float(feather_size),
+                )
+                mask[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = local_mask
+
+            # Build pyramid for mask
+            mask_pyramid = []
+            current_mask = mask
+            for i in range(pyramid_levels + 1):
+                mask_pyramid.append(current_mask)
+                if i < pyramid_levels:
+                    current_mask = ndimage.zoom(current_mask, 0.5, order=1)
+
+            # Blend each level of the pyramid
+            blended_pyramid = []
+            for level in range(len(tile_pyramid)):
+                mask_level = mask_pyramid[level]
+                level_height, level_width = output_pyramid[level].shape[:2]
+                if mask_level.shape[0] != level_height or mask_level.shape[1] != level_width:
+                    mask_level = ndimage.zoom(mask_level,
+                                            (level_height / mask_level.shape[0],
+                                            level_width / mask_level.shape[1]), order=1)
+
+                mask_level = mask_level[:, :, np.newaxis]
+                blended = output_pyramid[level] * (1 - mask_level) + tile_pyramid[level] * mask_level
+                blended_pyramid.append(blended)
+
+            output_pyramid = blended_pyramid
+            progress.update()
+
+        # Collapse pyramid to final image
+        output_array = StitchingPipeline._collapse_laplacian_pyramid(output_pyramid)
+        output_array = np.clip(output_array, 0, 255).astype(np.uint8)
+        return Image.fromarray(output_array)
+
+
+    @staticmethod
+    def _process_and_stitch_bilateral(
+        tiles: list[dict[str, object]],
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float,
+        mask_blur: int,
+        progress,
+        original_image: Image.Image,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+    ) -> Image.Image:
+        """Bilateral filtering-based stitching for edge-preserving blending."""
+        # Create base image
+        base_image = StitchingPipeline._create_base_image(
+            original_image,
+            width,
+            height,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        output_image = base_image.copy()
+        output_array = np.array(output_image, dtype=np.float32)
+        weight_array = np.zeros((height, width), dtype=np.float32)
+
+        # Batch process and upscale tiles
+        upscaled_tiles = StitchingPipeline._batch_upscale_tiles(
+            tiles,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            upscale_factor,
+            progress,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        # Process each tile
+        for tile_idx, tile_info in enumerate(tiles):
+            ai_upscaled_tile = upscaled_tiles[tile_idx]
+
+            progress.update_sub_progress("Resizing & Positioning", 2)
+            prepared = StitchingPipeline._prepare_tile_for_stitching(tile_info, ai_upscaled_tile, upscale_factor)
+            cropped_tile = prepared["cropped_tile"]
+            paste_x_adjusted = prepared["paste_x"]
+            paste_y_adjusted = prepared["paste_y"]
+
+            progress.update_sub_progress("Bilateral Filtering", 3)
+
+            # Apply bilateral filter to tile
+            tile_array = StitchingPipeline._apply_bilateral_filter(cropped_tile, d=9, sigma_color=75, sigma_space=75)
+            tile_array = tile_array.astype(np.float32)
+
+            # Define region
+            end_x = min(paste_x_adjusted + tile_array.shape[1], width)
+            end_y = min(paste_y_adjusted + tile_array.shape[0], height)
+            tile_height = end_y - paste_y_adjusted
+            tile_width = end_x - paste_x_adjusted
+            if tile_height <= 0 or tile_width <= 0:
+                progress.update()
+                continue
+
+            output_region = output_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            weight_region = weight_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            tile_region = tile_array[:tile_height, :tile_width]
+            tile_weight = StitchingPipeline._edge_weight_map(tile_height, tile_width, min_weight=0.1)
+
+            blended_region, new_weight = StitchingPipeline._blend_weighted_region(
+                output_region,
+                weight_region,
+                tile_region,
+                tile_weight,
+            )
+            output_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = blended_region
+            weight_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = new_weight
+
+            progress.update()
+
+        output_array = np.clip(output_array, 0, 255).astype(np.uint8)
+        return Image.fromarray(output_array)
+
+
+    @staticmethod
+    def _process_and_stitch_content_aware(
+        tiles: list[dict[str, object]],
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float,
+        mask_blur: int,
+        progress,
+        original_image: Image.Image,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+    ) -> Image.Image:
+        """Content-aware stitching using structure tensor for adaptive blending."""
+        # Create base image
+        base_image = StitchingPipeline._create_base_image(
+            original_image,
+            width,
+            height,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        output_array = np.array(base_image, dtype=np.float32)
+        weight_array = np.zeros((height, width), dtype=np.float32)
+
+        # Compute global structure for base image
+        base_edge_strength, base_coherence = StitchingPipeline._compute_structure_tensor(output_array)
+
+        # Batch process and upscale tiles
+        upscaled_tiles = StitchingPipeline._batch_upscale_tiles(
+            tiles,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            upscale_factor,
+            progress,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        # Process each tile
+        for tile_idx, tile_info in enumerate(tiles):
+            ai_upscaled_tile = upscaled_tiles[tile_idx]
+
+            progress.update_sub_progress("Resizing & Positioning", 2)
+            prepared = StitchingPipeline._prepare_tile_for_stitching(tile_info, ai_upscaled_tile, upscale_factor)
+            cropped_tile = prepared["cropped_tile"]
+            paste_x_adjusted = prepared["paste_x"]
+            paste_y_adjusted = prepared["paste_y"]
+
+            progress.update_sub_progress("Content-Aware Blending", 3)
+
+            tile_array = np.array(cropped_tile, dtype=np.float32)
+            tile_edge_strength, _tile_coherence = StitchingPipeline._compute_structure_tensor(tile_array)
+
+            end_x = min(paste_x_adjusted + tile_array.shape[1], width)
+            end_y = min(paste_y_adjusted + tile_array.shape[0], height)
+            tile_height = end_y - paste_y_adjusted
+            tile_width = end_x - paste_x_adjusted
+            if tile_height <= 0 or tile_width <= 0:
+                progress.update()
+                continue
+
+            output_region = output_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            weight_region = weight_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            tile_region = tile_array[:tile_height, :tile_width]
+
+            local_edge = base_edge_strength[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            local_coherence = base_coherence[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            tile_edge = tile_edge_strength[:tile_height, :tile_width]
+
+            tile_weight = 1.0 - local_coherence * 0.5
+            tile_weight = tile_weight * (1.0 + np.maximum(tile_edge - local_edge, 0.0))
+            tile_weight = tile_weight * StitchingPipeline._edge_weight_map(
+                tile_height,
+                tile_width,
+                min_weight=0.1,
+            )
+            tile_weight = tile_weight.astype(np.float32, copy=False)
+
+            blended_region, new_weight = StitchingPipeline._blend_weighted_region(
+                output_region,
+                weight_region,
+                tile_region,
+                tile_weight,
+            )
+            output_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = blended_region
+            weight_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = new_weight
+
+            progress.update()
+
+        output_array = np.clip(output_array, 0, 255).astype(np.uint8)
+        return Image.fromarray(output_array)
+
+
+    @staticmethod
+    def _process_and_stitch_zero_blur(
+        tiles: list[dict[str, object]],
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float,
+        progress,
+        original_image: Image.Image,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+        ) -> Image.Image:
+        """Zero-blur stitching that preserves maximum detail through precise pixel averaging."""
+        # Create base image
+        base_image = StitchingPipeline._create_base_image(
+            original_image,
+            width,
+            height,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        output_array = np.array(base_image, dtype=np.float32)
+        weight_array = np.zeros((height, width), dtype=np.float32)
+
+        # Batch process and upscale tiles
+        upscaled_tiles = StitchingPipeline._batch_upscale_tiles(
+            tiles,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            upscale_factor,
+            progress,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        # Process each upscaled tile for stitching
+        for tile_idx, tile_info in enumerate(tiles):
+            ai_upscaled_tile = upscaled_tiles[tile_idx]
+
+            progress.update_sub_progress("Resizing & Positioning", 2)
+            prepared = StitchingPipeline._prepare_tile_for_stitching(tile_info, ai_upscaled_tile, upscale_factor)
+            cropped_tile = prepared["cropped_tile"]
+            paste_x_adjusted = prepared["paste_x"]
+            paste_y_adjusted = prepared["paste_y"]
+
+            tile_array = np.array(cropped_tile, dtype=np.float32)
+
+            progress.update_sub_progress("Seamless Blending", 3)
+
+            end_x = min(paste_x_adjusted + tile_array.shape[1], width)
+            end_y = min(paste_y_adjusted + tile_array.shape[0], height)
+
+            tile_height = end_y - paste_y_adjusted
+            tile_width = end_x - paste_x_adjusted
+            if tile_height <= 0 or tile_width <= 0:
+                progress.update()
+                continue
+
+            output_region = output_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            weight_region = weight_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x]
+            tile_region = tile_array[:tile_height, :tile_width]
+
+            new_weight = weight_region + 1.0
+            output_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = (
+                output_region * weight_region[:, :, np.newaxis] + tile_region
+            ) / new_weight[:, :, np.newaxis]
+            weight_array[paste_y_adjusted:end_y, paste_x_adjusted:end_x] = new_weight
+
+            progress.update()
+
+        output_array = np.clip(output_array, 0, 255).astype(np.uint8)
+        return Image.fromarray(output_array)
+
+
+    @staticmethod
+    def _process_and_stitch_blended(
+        tiles: list[dict[str, object]],
+        width: int,
+        height: int,
+        dit_config: dict[str, Any],
+        vae_config: dict[str, Any],
+        seed: int,
+        tile_upscale_resolution: int,
+        upscale_factor: float,
+        mask_blur: int,
+        progress,
+        original_image: Image.Image,
+        color_correction: str = "lab",
+        input_noise_scale: float = 0.0,
+        offload_device: str = "cpu",
+        enable_debug: bool = False,
+        ) -> Image.Image:
+        """Standard blended stitching with user-controlled blur."""
+        # Create base image
+        base_image = StitchingPipeline._create_base_image(
+            original_image,
+            width,
+            height,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        output_rgba = base_image.convert("RGBA")
+        mask_cache: dict[tuple[object, ...], Image.Image] = {}
+        use_dest_alpha_composite = True
+
+        # Batch process and upscale tiles
+        upscaled_tiles = StitchingPipeline._batch_upscale_tiles(
+            tiles,
+            dit_config,
+            vae_config,
+            seed,
+            tile_upscale_resolution,
+            upscale_factor,
+            progress,
+            color_correction,
+            input_noise_scale,
+            offload_device,
+            enable_debug,
+        )
+
+        # Process each upscaled tile for stitching
+        for tile_idx, tile_info in enumerate(tiles):
+            ai_upscaled_tile = upscaled_tiles[tile_idx]
+
+            progress.update_sub_progress("Resizing & Positioning", 2)
+            prepared = StitchingPipeline._prepare_tile_for_stitching(tile_info, ai_upscaled_tile, upscale_factor)
+            cropped_tile = prepared["cropped_tile"]
+            paste_x_adjusted = prepared["paste_x"]
+            paste_y_adjusted = prepared["paste_y"]
+            keep_left, keep_top, keep_right, keep_bottom = prepared["keep_padding"]
+
+            progress.update_sub_progress("Mask Blending", 3)
+
+            # Create mask with user-specified blur
+            actual_crop_width = cropped_tile.width
+            actual_crop_height = cropped_tile.height
+            padding_info = tuple(int(v) for v in tile_info["padding"])
+            keep_padding = (keep_left, keep_top, keep_right, keep_bottom)
+            mask_key = (
+                actual_crop_width,
+                actual_crop_height,
+                int(mask_blur),
+                padding_info,
+                keep_padding,
+            )
+
+            tile_mask = mask_cache.get(mask_key)
+            if tile_mask is None:
+                tile_mask = StitchingPipeline._create_precise_tile_mask(
+                    actual_crop_width,
+                    actual_crop_height,
+                    mask_blur,
+                    padding_info,
+                    keep_left,
+                    keep_top,
+                    keep_right,
+                    keep_bottom,
+                )
+                mask_cache[mask_key] = tile_mask
+
+            tile_rgba = cropped_tile.convert("RGBA")
+            tile_rgba.putalpha(tile_mask)
+
+            if use_dest_alpha_composite:
+                try:
+                    output_rgba.alpha_composite(
+                        tile_rgba,
+                        dest=(paste_x_adjusted, paste_y_adjusted),
+                    )
+                except TypeError:
+                    use_dest_alpha_composite = False
+
+            if not use_dest_alpha_composite:
+                tile_canvas = Image.new("RGBA", output_rgba.size, (0, 0, 0, 0))
+                tile_canvas.paste(tile_rgba, (paste_x_adjusted, paste_y_adjusted))
+                output_rgba.alpha_composite(tile_canvas)
+
+            progress.update()
+
+        return output_rgba.convert("RGB")
+
+
+    @staticmethod
+    def _create_precise_tile_mask(
+        width: int,
+        height: int,
+        blur_radius: int,
+        padding_info: tuple[int, int, int, int],
+        keep_left: int = 0,
+        keep_top: int = 0,
+        keep_right: int = 0,
+        keep_bottom: int = 0,
+    ) -> Image.Image:
+        """Create smart blending mask with proper overlap handling on all sides."""
+        left_pad, top_pad, right_pad, bottom_pad = padding_info
+        mask_array = np.full((height, width), 255, dtype=np.uint8)
+
+        if blur_radius > 0 and width > 0 and height > 0:
+            overlap_width_left = keep_left * 2 if keep_left > 0 else 0
+            overlap_width_top = keep_top * 2 if keep_top > 0 else 0
+            overlap_width_right = keep_right * 2 if keep_right > 0 else 0
+            overlap_width_bottom = keep_bottom * 2 if keep_bottom > 0 else 0
+
+            if left_pad > 0 and overlap_width_left > 0:
+                left_extent = min(width, overlap_width_left)
+                x = np.arange(left_extent, dtype=np.int32)
+                fade_left = ((255 * x) // overlap_width_left).astype(np.uint8)
+                mask_array[:, :left_extent] = np.minimum(
+                    mask_array[:, :left_extent],
+                    fade_left[np.newaxis, :],
+                )
+
+            if top_pad > 0 and overlap_width_top > 0:
+                top_extent = min(height, overlap_width_top)
+                y = np.arange(top_extent, dtype=np.int32)
+                fade_top = ((255 * y) // overlap_width_top).astype(np.uint8)
+                mask_array[:top_extent, :] = np.minimum(
+                    mask_array[:top_extent, :],
+                    fade_top[:, np.newaxis],
+                )
+
+            if right_pad > 0 and overlap_width_right > 0:
+                start_x = width - overlap_width_right
+                effective_start_x = max(0, start_x)
+                x = np.arange(effective_start_x, width, dtype=np.int32)
+                distance = x - start_x
+                fade_right = ((255 * (overlap_width_right - distance)) // overlap_width_right).astype(np.uint8)
+                mask_array[:, effective_start_x:width] = np.minimum(
+                    mask_array[:, effective_start_x:width],
+                    fade_right[np.newaxis, :],
+                )
+
+            if bottom_pad > 0 and overlap_width_bottom > 0:
+                start_y = height - overlap_width_bottom
+                effective_start_y = max(0, start_y)
+                y = np.arange(effective_start_y, height, dtype=np.int32)
+                distance = y - start_y
+                fade_bottom = ((255 * (overlap_width_bottom - distance)) // overlap_width_bottom).astype(np.uint8)
+                mask_array[effective_start_y:height, :] = np.minimum(
+                    mask_array[effective_start_y:height, :],
+                    fade_bottom[:, np.newaxis],
+                )
+
+        return Image.fromarray(mask_array)

--- a/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/tiling.py
+++ b/python/ComfyUI-SeedVR2_ImageUpscaler/seedvr2_image_upscaler/tiling.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+from typing import Literal
+
+
+class TileUtils:
+    _GPU_DIM_ALIGNMENT = 16
+
+    @staticmethod
+    def _compute_axis_positions(length: int, tile_size: int) -> list[int]:
+        """Compute axis-aligned tile starts while avoiding tiny remainder tiles at the boundary."""
+        if length <= tile_size:
+            return [0]
+
+        positions = list(range(0, length, tile_size))
+        if not positions:
+            return [0]
+
+        # Shift the final tile so it ends on the image boundary.
+        positions[-1] = max(0, length - tile_size)
+
+        deduped: list[int] = []
+        for pos in positions:
+            if not deduped or deduped[-1] != pos:
+                deduped.append(pos)
+        return deduped
+
+    @staticmethod
+    def generate_tiles(
+        image: Image.Image,
+        tile_size: int,
+        tile_overlap: int,
+        strategy: Literal["Linear", "Chess"] = "Linear",
+    ) -> list[dict[str, object]]:
+        """Generate square tiles with overlap based on the specified strategy."""
+        if tile_size <= 64:
+            tile_size = 64
+        if tile_overlap < 0:
+            tile_overlap = 0
+
+        width, height = image.size
+        x_positions = TileUtils._compute_axis_positions(width, tile_size)
+        y_positions = TileUtils._compute_axis_positions(height, tile_size)
+
+        positions: list[tuple[int, int]] = []
+        if strategy == "Chess":
+            even_positions: list[tuple[int, int]] = []
+            odd_positions: list[tuple[int, int]] = []
+            for y_idx, y in enumerate(y_positions):
+                for x_idx, x in enumerate(x_positions):
+                    if ((x_idx + y_idx) & 1) == 0:
+                        even_positions.append((x, y))
+                    else:
+                        odd_positions.append((x, y))
+            positions = even_positions + odd_positions
+        else:
+            positions = [(x, y) for y in y_positions for x in x_positions]
+
+        return [
+            TileUtils.get_tile_info(image, x, y, tile_size, tile_overlap)
+            for x, y in positions
+        ]
+
+    @staticmethod
+    def calculate_efficient_tile_size(width: int, height: int) -> tuple[int, int]:
+        """Round dimensions up to GPU-friendly alignment without over-padding tiny tiles."""
+        alignment = TileUtils._GPU_DIM_ALIGNMENT
+        efficient_width = max(alignment, ((width + alignment - 1) // alignment) * alignment)
+        efficient_height = max(alignment, ((height + alignment - 1) // alignment) * alignment)
+
+        return efficient_width, efficient_height
+
+    @staticmethod
+    def get_tile_info(
+        image: Image.Image,
+        x: int,
+        y: int,
+        tile_size: int,
+        tile_overlap: int,
+    ) -> dict[str, object]:
+        """Extract tile information and crop the tile with padding.
+
+        Uses edge extension (reflection) for memory padding instead of solid color fill
+        to avoid artificial edges that the AI upscaler would process as real content.
+        """
+        width, height = image.size
+
+        # Calculate actual tile boundaries (may be smaller at edges)
+        actual_tile_width = min(tile_size, width - x)
+        actual_tile_height = min(tile_size, height - y)
+
+        # Calculate padding (only add padding where there are adjacent tiles)
+        left_pad = tile_overlap if x > 0 else 0
+        top_pad = tile_overlap if y > 0 else 0
+        right_pad = tile_overlap if x + tile_size < width else 0
+        bottom_pad = tile_overlap if y + tile_size < height else 0
+
+        # Create the padded crop box
+        padded_box = (
+            max(0, x - left_pad),
+            max(0, y - top_pad),
+            min(width, x + actual_tile_width + right_pad),
+            min(height, y + actual_tile_height + bottom_pad),
+        )
+
+        tile = image.crop(padded_box)
+
+        # Calculate efficient dimensions for GPU processing
+        current_width, current_height = tile.size
+        efficient_width, efficient_height = TileUtils.calculate_efficient_tile_size(current_width, current_height)
+
+        # Add memory padding if needed for GPU efficiency
+        memory_pad_right = efficient_width - current_width
+        memory_pad_bottom = efficient_height - current_height
+
+        if memory_pad_right > 0 or memory_pad_bottom > 0:
+            tile = TileUtils._pad_tile_with_reflection(
+                tile=tile,
+                current_width=current_width,
+                current_height=current_height,
+                memory_pad_right=memory_pad_right,
+                memory_pad_bottom=memory_pad_bottom,
+                efficient_width=efficient_width,
+                efficient_height=efficient_height,
+            )
+
+        return {
+            "tile": tile,
+            "position": (x, y),
+            "actual_size": (actual_tile_width, actual_tile_height),
+            "padding": (left_pad, top_pad, right_pad, bottom_pad),
+            "memory_padding": (0, 0, memory_pad_right, memory_pad_bottom),
+            "original_tile_size": (current_width, current_height),
+        }
+
+    @staticmethod
+    def _pad_tile_with_reflection(
+        tile: Image.Image,
+        current_width: int,
+        current_height: int,
+        memory_pad_right: int,
+        memory_pad_bottom: int,
+        efficient_width: int,
+        efficient_height: int,
+    ) -> Image.Image:
+        """Pad right/bottom edges using reflection, then edge-repeat if pad exceeds source size."""
+        tile_array = np.asarray(tile)
+        has_channels = tile_array.ndim == 3
+        if not has_channels:
+            tile_array = tile_array[:, :, np.newaxis]
+
+        padded_array = np.empty(
+            (efficient_height, efficient_width, tile_array.shape[2]),
+            dtype=tile_array.dtype,
+        )
+        padded_array[:current_height, :current_width] = tile_array
+
+        reflect_width = min(memory_pad_right, current_width)
+        reflect_height = min(memory_pad_bottom, current_height)
+        remaining_right = memory_pad_right - reflect_width
+        remaining_bottom = memory_pad_bottom - reflect_height
+
+        if reflect_width > 0:
+            padded_array[:current_height, current_width:current_width + reflect_width] = (
+                tile_array[:, current_width - reflect_width:current_width][:, ::-1]
+            )
+        if remaining_right > 0:
+            padded_array[:current_height, current_width + reflect_width:efficient_width] = tile_array[:, -1:, :]
+
+        if reflect_height > 0:
+            padded_array[current_height:current_height + reflect_height, :current_width] = (
+                tile_array[current_height - reflect_height:current_height, :][::-1, :]
+            )
+        if remaining_bottom > 0:
+            padded_array[current_height + reflect_height:efficient_height, :current_width] = tile_array[-1:, :, :]
+
+        if memory_pad_right > 0 and memory_pad_bottom > 0:
+            corner = tile_array[
+                current_height - reflect_height:current_height,
+                current_width - reflect_width:current_width,
+            ]
+            padded_array[
+                current_height:current_height + reflect_height,
+                current_width:current_width + reflect_width,
+            ] = corner[::-1, ::-1]
+
+            if remaining_right > 0:
+                corner_edge_col = padded_array[
+                    current_height:current_height + reflect_height,
+                    current_width + reflect_width - 1:current_width + reflect_width,
+                ]
+                padded_array[
+                    current_height:current_height + reflect_height,
+                    current_width + reflect_width:efficient_width,
+                ] = np.repeat(corner_edge_col, remaining_right, axis=1)
+            if remaining_bottom > 0:
+                corner_edge_row = padded_array[
+                    current_height + reflect_height - 1:current_height + reflect_height,
+                    current_width:current_width + reflect_width,
+                ]
+                padded_array[
+                    current_height + reflect_height:efficient_height,
+                    current_width:current_width + reflect_width,
+                ] = np.repeat(corner_edge_row, remaining_bottom, axis=0)
+            if remaining_right > 0 and remaining_bottom > 0:
+                padded_array[
+                    current_height + reflect_height:efficient_height,
+                    current_width + reflect_width:efficient_width,
+                ] = tile_array[-1, -1]
+
+        if not has_channels:
+            padded_array = padded_array[:, :, 0]
+
+        return Image.fromarray(padded_array)

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,52 @@
+# Vendored Python nodes
+
+`ComfyUI-SeedVR2_ImageUpscaler/` is a vendored copy of
+[jtreminio/ComfyUI-SeedVR2_ImageUpscaler](https://github.com/jtreminio/ComfyUI-SeedVR2_ImageUpscaler)
+(MIT license, see `ComfyUI-SeedVR2_ImageUpscaler/LICENSE`), itself a fork of
+[moonwhaler/comfyui-seedvr2-tilingupscaler](https://github.com/moonwhaler/comfyui-seedvr2-tilingupscaler).
+
+## Why this is vendored instead of installed
+
+SwarmUI core also bundles a copy of this same package directly (as a "DLNode", under
+`src/BuiltinExtensions/ComfyUIBackend/DLNodes/ComfyUI-SeedVR2_ImageUpscaler`), which is what
+actually provides the `SeedVR2ImageUpscaler` ComfyUI node today - this extension's own
+`InstallableFeature` for it (see `SeedVR2UpscalerExtension.cs`) currently never fires, since
+core's copy already satisfies that feature flag first.
+
+That upstream/core copy has a bug: `_batch_upscale_tiles` in `stitching.py` color-corrects
+each tile independently against only its own local crop. Tiles with different content (e.g.
+skin vs. background) drift to different color statistics, and the mismatch shows up as a
+visible, often smeared, discolored patch right at the tile boundary once stitched - most
+visible on limbs/extremities, since those are more likely to straddle a tile edge than a
+centered face or torso.
+
+The copy here has that fixed: per-tile color correction is disabled, and the requested
+correction is instead applied once, globally, after stitching, against the existing
+`_create_base_image` reference (see `_match_color_lab` in `stitching.py`). PRs with the same
+fix are open against both jtreminio's and moonwhaler's repos; this vendored copy exists so the
+fix is live immediately rather than waiting on either to merge, and stays live even if SwarmUI
+core's own DLNodes copy gets out of sync or reverted.
+
+## How it takes effect
+
+`SeedVR2UpscalerExtension.OnInit()` registers this folder with
+`ComfyUISelfStartBackend.CustomNodePaths`. ComfyUI loads custom node roots in order
+(`DLNodes;ExtraNodes;{CustomNodePaths}` - see `ComfyUISelfStartBackend.cs`), and
+`load_custom_node()` does a plain `NODE_CLASS_MAPPINGS[name] = node_cls` overwrite with no
+duplicate check against nodes loaded earlier in the same pass. Since `CustomNodePaths` loads
+after `DLNodes`, this copy's `SeedVR2ImageUpscaler` registration deterministically wins over
+core's.
+
+This has no effect on SwarmUI core's *native* SeedVR2 support (`CreateSeedVR2Restore` /
+`RunSeedVR2Stage` in `WorkflowGenerator.cs`), which is built entirely from separate primitive
+nodes (`SeedVR2Preprocess`, `SeedVR2Conditioning`, `SeedVR2TemporalChunk`,
+`SeedVR2TemporalMerge`, `SeedVR2PostProcessing`) defined in ComfyUI's own
+`comfy_extras/nodes_seedvr.py` and loaded through a different code path
+(`init_builtin_extra_nodes`, not `init_external_custom_nodes`). Native support never
+references `SeedVR2ImageUpscaler` at all.
+
+## Updating
+
+If jtreminio's or moonwhaler's PR merges (or any other upstream change is worth pulling in),
+re-sync this folder from the upstream repo and re-apply the `_match_color_lab` /
+`_batch_upscale_tiles` changes if they haven't landed yet.


### PR DESCRIPTION
## Summary

- SwarmUI core bundles `jtreminio/ComfyUI-SeedVR2_ImageUpscaler` as a DLNode, which is what
  actually provides the `SeedVR2ImageUpscaler` ComfyUI node today - this extension's own
  `InstallableFeature` for it never fires, since core's copy already satisfies that feature
  flag first.
- That copy has a bug: `_batch_upscale_tiles` in `stitching.py` color-corrects each tile
  independently against only its own local crop. Tiles with different content (skin vs.
  background, etc.) drift to different color statistics, and the mismatch shows up as a
  visible, often smeared, discolored patch right at the tile boundary once stitched - most
  often on limbs/extremities, since those are more likely to straddle a tile edge than a
  centered face or torso.
- `python/ComfyUI-SeedVR2_ImageUpscaler/` vendors that package with the fix applied: per-tile
  color correction disabled, requested correction applied once globally after stitching
  against the existing `_create_base_image` reference (`_match_color_lab`). PRs with the same
  fix are open against jtreminio's and moonwhaler's repos; this vendored copy means the fix is
  live immediately and stays live regardless of either PR's fate.
- `OnInit()` registers `python/` with `ComfyUISelfStartBackend.CustomNodePaths`, which ComfyUI
  loads after `DLNodes`, so this copy deterministically overrides core's. Full mechanism +
  why this can't affect SwarmUI's *native* SeedVR2 support (different nodes entirely,
  different loading phase) is in `python/README.md`.

## Test plan

- [x] `dotnet build` of the extension's real auto-generated csproj (mirroring
      `ExtensionsManager.BuildExtension`) - 0 warnings, 0 errors.
- [x] Vendored package's own unit tests (`tests/test_stitching.py`, run from the source repo
      before vendoring) - all pass, including two new tests added for this fix.
- [ ] Restart the ComfyUI backend, confirm the startup log shows this `python/` path loading
      after `DLNodes` for the `SeedVR2ImageUpscaler` node.
- [ ] Re-run a tiled upscale on a prompt/seed that previously showed the smeared
      limb/extremity artifact; confirm it's gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)